### PR TITLE
chore: normalize content frontmatter dates to KST (+09:00)

### DIFF
--- a/scripts/normalize-dates.mjs
+++ b/scripts/normalize-dates.mjs
@@ -1,0 +1,50 @@
+// frontmatter의 date 값이 KST 의도로 적혀 있으나 "Z" (UTC) 표기로 저장돼 있어
+// 표시 시 하루 밀려 보이는 문제를 보정한다.
+// 예: "2026-05-16T21:31:00.000Z" -> "2026-05-16T21:31:00+09:00"
+// 멱등하므로 반복 실행해도 안전하다.
+
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOTS = [
+  'src/content/weekly',
+  'src/content/blog',
+  'src/content/archive',
+];
+
+const RE = /^(date:\s*")(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.\d+)?Z(")\s*$/m;
+
+let scanned = 0;
+let updated = 0;
+const skipped = [];
+
+for (const root of ROOTS) {
+  let entries;
+  try {
+    entries = readdirSync(root);
+  } catch (e) {
+    if (e.code === 'ENOENT') continue;
+    throw e;
+  }
+  for (const name of entries) {
+    if (!/\.mdx?$/.test(name)) continue;
+    scanned++;
+    const fp = join(root, name);
+    const before = readFileSync(fp, 'utf8');
+    if (!RE.test(before)) {
+      skipped.push(fp);
+      continue;
+    }
+    const after = before.replace(RE, '$1$2+09:00$3');
+    if (after !== before) {
+      writeFileSync(fp, after);
+      updated++;
+    }
+  }
+}
+
+console.log(`scanned: ${scanned}, updated: ${updated}, skipped: ${skipped.length}`);
+if (skipped.length > 0) {
+  console.log('files without a matching `date: "...Z"` frontmatter:');
+  for (const fp of skipped) console.log(`  ${fp}`);
+}

--- a/src/content/archive/deno.md
+++ b/src/content/archive/deno.md
@@ -1,6 +1,6 @@
 ---
 title: Deno
-date: "2024-01-25T00:00:00.000Z"
+date: "2024-01-25T00:00:00+09:00"
 description: "Deno Archive"
 tags: ["javascript", "deno", "fresh"]
 ---

--- a/src/content/archive/typescript.md
+++ b/src/content/archive/typescript.md
@@ -1,6 +1,6 @@
 ---
 title: Typescript Archive
-date: "2023-11-20T00:00:00.000Z"
+date: "2023-11-20T00:00:00+09:00"
 description: "Typescript Update History"
 tags: ["javascript", "typescript"]
 ---

--- a/src/content/blog/About-Rendering-In-The-Browser.md
+++ b/src/content/blog/About-Rendering-In-The-Browser.md
@@ -1,6 +1,6 @@
 ---
 title: About Rendering In The Browser
-date: "2020-10-23T00:00:00.000Z"
+date: "2020-10-23T00:00:00+09:00"
 description: "브라우저의 렌더링에 대하여."
 tags: ["browser"]
 ---

--- a/src/content/blog/Asynchronous.md
+++ b/src/content/blog/Asynchronous.md
@@ -1,6 +1,6 @@
 ---
 title: Asynchronous
-date: "2023-03-30T00:00:00.000Z"
+date: "2023-03-30T00:00:00+09:00"
 description: "Asynchronous"
 tags: ["Asynchronous"]
 ---

--- a/src/content/blog/JS-Memory-Model.md
+++ b/src/content/blog/JS-Memory-Model.md
@@ -1,6 +1,6 @@
 ---
 title: JS Memory Model
-date: "2023-04-06T00:00:00.000Z"
+date: "2023-04-06T00:00:00+09:00"
 description: "JS Memory Modal by rsc"
 tags: ["javascript"]
 ---

--- a/src/content/blog/Priority-Scheduler.md
+++ b/src/content/blog/Priority-Scheduler.md
@@ -1,6 +1,6 @@
 ---
 title: Priority Scheduler
-date: "2023-02-07T00:00:00.000Z"
+date: "2023-02-07T00:00:00+09:00"
 description: "Priority Scheduler"
 tags: ["browser"]
 ---

--- a/src/content/blog/Software-Engineering-The-Soft-Parts_ko.md
+++ b/src/content/blog/Software-Engineering-The-Soft-Parts_ko.md
@@ -1,6 +1,6 @@
 ---
 title: Software Engineering - The Soft Parts 번역
-date: "2023-04-17T01:55:00.000Z"
+date: "2023-04-17T01:55:00+09:00"
 description: "Software Engineering - The Soft Parts 번역"
 tags: ["translate"]
 ---

--- a/src/content/blog/WebClient_Performance_Improve.md
+++ b/src/content/blog/WebClient_Performance_Improve.md
@@ -1,6 +1,6 @@
 ---
 title: WebClient Performance Improve
-date: "2023-05-16T00:00:00.000Z"
+date: "2023-05-16T00:00:00+09:00"
 description: "WebClient Performance Improve. 웹의 성능은 무엇이고, 어떤걸 개선해야 하는지에 대한 개요 문서"
 tags: ["performance", "javascript", "css", "font", "image"]
 ---

--- a/src/content/weekly/dev-weekly-20210213.md
+++ b/src/content/weekly/dev-weekly-20210213.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-02-13
-date: "2021-02-13T09:00:00.000Z"
+date: "2021-02-13T09:00:00+09:00"
 description: "dev-weekly 2021-02-13"
 tags: ["javascript", "css", "node", "web", "typescript", "deno"]
 ---

--- a/src/content/weekly/dev-weekly-20210220.md
+++ b/src/content/weekly/dev-weekly-20210220.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-02-20
-date: "2021-02-20T09:00:00.000Z"
+date: "2021-02-20T09:00:00+09:00"
 description: "dev-weekly 2021-02-20"
 tags: ["javascript", "css", "node", "web", "typescript", "go"]
 ---

--- a/src/content/weekly/dev-weekly-20210227.md
+++ b/src/content/weekly/dev-weekly-20210227.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-02-27
-date: "2021-02-27T08:30:00.000Z"
+date: "2021-02-27T08:30:00+09:00"
 description: "dev-weekly 2021-02-27"
 tags: ["javascript", "css", "node", "web", "DB"]
 ---

--- a/src/content/weekly/dev-weekly-20210306.md
+++ b/src/content/weekly/dev-weekly-20210306.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-03-06
-date: "2021-03-06T08:40:00.000Z"
+date: "2021-03-06T08:40:00+09:00"
 description: "dev-weekly 2021-03-06"
 tags: ["javascript", "css", "node", "deno", "go"]
 ---

--- a/src/content/weekly/dev-weekly-20210313.md
+++ b/src/content/weekly/dev-weekly-20210313.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-03-13
-date: "2021-03-13T11:30:00.000Z"
+date: "2021-03-13T11:30:00+09:00"
 description: "dev-weekly 2021-03-13"
 tags: ["javascript", "css", "node", "deno", "go"]
 ---

--- a/src/content/weekly/dev-weekly-20210320.md
+++ b/src/content/weekly/dev-weekly-20210320.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-03-20
-date: "2021-03-20T09:10:00.000Z"
+date: "2021-03-20T09:10:00+09:00"
 description: "dev-weekly 2021-03-20"
 tags: ["javascript", "css", "go", "db"]
 ---

--- a/src/content/weekly/dev-weekly-20210327.md
+++ b/src/content/weekly/dev-weekly-20210327.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-03-27
-date: "2021-03-27T10:00:00.000Z"
+date: "2021-03-27T10:00:00+09:00"
 description: "dev-weekly 2021-03-27"
 tags: ["javascript", "css", "go", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20210403.md
+++ b/src/content/weekly/dev-weekly-20210403.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-04-03
-date: "2021-04-03T09:10:00.000Z"
+date: "2021-04-03T09:10:00+09:00"
 description: "dev-weekly 2021-04-03"
 tags: ["javascript", "css", "go", "node", "deno"]
 ---

--- a/src/content/weekly/dev-weekly-20210410.md
+++ b/src/content/weekly/dev-weekly-20210410.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-04-10
-date: "2021-04-10T09:40:00.000Z"
+date: "2021-04-10T09:40:00+09:00"
 description: "dev-weekly 2021-04-10"
 tags: ["javascript", "css", "go", "db"]
 ---

--- a/src/content/weekly/dev-weekly-20210417.md
+++ b/src/content/weekly/dev-weekly-20210417.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-04-17
-date: "2021-04-17T10:10:00.000Z"
+date: "2021-04-17T10:10:00+09:00"
 description: "dev-weekly 2021-04-17"
 tags: ["javascript", "css", "go", "db"]
 ---

--- a/src/content/weekly/dev-weekly-20210424.md
+++ b/src/content/weekly/dev-weekly-20210424.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-04-24
-date: "2021-04-24T09:30:00.000Z"
+date: "2021-04-24T09:30:00+09:00"
 description: "dev-weekly 2021-04-24"
 tags: ["javascript", "css", "go", "db"]
 ---

--- a/src/content/weekly/dev-weekly-20210501.md
+++ b/src/content/weekly/dev-weekly-20210501.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-05-01
-date: "2021-05-01T09:40:00.000Z"
+date: "2021-05-01T09:40:00+09:00"
 description: "dev-weekly 2021-05-01"
 tags: ["javascript", "css", "db"]
 ---

--- a/src/content/weekly/dev-weekly-20210508.md
+++ b/src/content/weekly/dev-weekly-20210508.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-05-08
-date: "2021-05-08T11:30:00.000Z"
+date: "2021-05-08T11:30:00+09:00"
 description: "dev-weekly 2021-05-08"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20210515.md
+++ b/src/content/weekly/dev-weekly-20210515.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-05-15
-date: "2021-05-15T09:30:00.000Z"
+date: "2021-05-15T09:30:00+09:00"
 description: "dev-weekly 2021-05-15"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20210522.md
+++ b/src/content/weekly/dev-weekly-20210522.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-05-22
-date: "2021-05-22T14:30:00.000Z"
+date: "2021-05-22T14:30:00+09:00"
 description: "dev-weekly 2021-05-22"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20210529.md
+++ b/src/content/weekly/dev-weekly-20210529.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-05-29
-date: "2021-05-29T09:30:00.000Z"
+date: "2021-05-29T09:30:00+09:00"
 description: "dev-weekly 2021-05-29"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20210605.md
+++ b/src/content/weekly/dev-weekly-20210605.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-06-05
-date: "2021-06-05T10:10:00.000Z"
+date: "2021-06-05T10:10:00+09:00"
 description: "dev-weekly 2021-06-05"
 tags: ["javascript", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20210612.md
+++ b/src/content/weekly/dev-weekly-20210612.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-06-12
-date: "2021-06-12T08:30:00.000Z"
+date: "2021-06-12T08:30:00+09:00"
 description: "dev-weekly 2021-06-12"
 tags: ["javascript", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20210619.md
+++ b/src/content/weekly/dev-weekly-20210619.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-06-19
-date: "2021-06-19T19:00:00.000Z"
+date: "2021-06-19T19:00:00+09:00"
 description: "dev-weekly 2021-06-19"
 tags: ["javascript", "node", "CSS"]
 ---

--- a/src/content/weekly/dev-weekly-20210626.md
+++ b/src/content/weekly/dev-weekly-20210626.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-06-26
-date: "2021-06-26T09:00:00.000Z"
+date: "2021-06-26T09:00:00+09:00"
 description: "dev-weekly 2021-06-26"
 tags: ["javascript", "node", "CSS"]
 ---

--- a/src/content/weekly/dev-weekly-20210703.md
+++ b/src/content/weekly/dev-weekly-20210703.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-07-03
-date: "2021-07-03T09:30:00.000Z"
+date: "2021-07-03T09:30:00+09:00"
 description: "dev-weekly 2021-07-03"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20210710.md
+++ b/src/content/weekly/dev-weekly-20210710.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-07-10
-date: "2021-07-10T14:00:00.000Z"
+date: "2021-07-10T14:00:00+09:00"
 description: "dev-weekly 2021-07-10"
 tags: ["javascript", "node", "deno", "go"]
 ---

--- a/src/content/weekly/dev-weekly-20210717.md
+++ b/src/content/weekly/dev-weekly-20210717.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-07-17
-date: "2021-07-17T10:30:00.000Z"
+date: "2021-07-17T10:30:00+09:00"
 description: "dev-weekly 2021-07-17"
 tags: ["javascript", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20210724.md
+++ b/src/content/weekly/dev-weekly-20210724.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-07-24
-date: "2021-07-24T09:00:00.000Z"
+date: "2021-07-24T09:00:00+09:00"
 description: "dev-weekly 2021-07-24"
 tags: ["javascript", "node", "css", "go"]
 ---

--- a/src/content/weekly/dev-weekly-20210731.md
+++ b/src/content/weekly/dev-weekly-20210731.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-07-31
-date: "2021-07-31T09:00:00.000Z"
+date: "2021-07-31T09:00:00+09:00"
 description: "dev-weekly 2021-07-31"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20210807.md
+++ b/src/content/weekly/dev-weekly-20210807.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-08-07
-date: "2021-08-07T10:00:00.000Z"
+date: "2021-08-07T10:00:00+09:00"
 description: "dev-weekly 2021-08-07"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20210814.md
+++ b/src/content/weekly/dev-weekly-20210814.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-08-14
-date: "2021-08-14T09:00:00.000Z"
+date: "2021-08-14T09:00:00+09:00"
 description: "dev-weekly 2021-08-14"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20210821.md
+++ b/src/content/weekly/dev-weekly-20210821.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-08-21
-date: "2021-08-21T09:00:00.000Z"
+date: "2021-08-21T09:00:00+09:00"
 description: "dev-weekly 2021-08-21"
 tags: ["javascript", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20210828.md
+++ b/src/content/weekly/dev-weekly-20210828.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-08-28
-date: "2021-08-28T09:00:00.000Z"
+date: "2021-08-28T09:00:00+09:00"
 description: "dev-weekly 2021-08-28"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20210904.md
+++ b/src/content/weekly/dev-weekly-20210904.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-09-04
-date: "2021-09-04T16:00:00.000Z"
+date: "2021-09-04T16:00:00+09:00"
 description: "dev-weekly 2021-09-04"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20210911.md
+++ b/src/content/weekly/dev-weekly-20210911.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-09-11
-date: "2021-09-11T11:00:00.000Z"
+date: "2021-09-11T11:00:00+09:00"
 description: "dev-weekly 2021-09-11"
 tags: ["javascript", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20210918.md
+++ b/src/content/weekly/dev-weekly-20210918.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-09-18
-date: "2021-09-18T11:00:00.000Z"
+date: "2021-09-18T11:00:00+09:00"
 description: "dev-weekly 2021-09-18"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20210925.md
+++ b/src/content/weekly/dev-weekly-20210925.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-09-25
-date: "2021-09-25T11:00:00.000Z"
+date: "2021-09-25T11:00:00+09:00"
 description: "dev-weekly 2021-09-25"
 tags: ["javascript", "node", "css", "rust"]
 ---

--- a/src/content/weekly/dev-weekly-20211002.md
+++ b/src/content/weekly/dev-weekly-20211002.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-10-02
-date: "2021-10-02T11:00:00.000Z"
+date: "2021-10-02T11:00:00+09:00"
 description: "dev-weekly 2021-10-02"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20211009.md
+++ b/src/content/weekly/dev-weekly-20211009.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-10-09
-date: "2021-10-09T21:30:00.000Z"
+date: "2021-10-09T21:30:00+09:00"
 description: "dev-weekly 2021-10-09"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20211016.md
+++ b/src/content/weekly/dev-weekly-20211016.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-10-16
-date: "2021-10-16T10:00:00.000Z"
+date: "2021-10-16T10:00:00+09:00"
 description: "dev-weekly 2021-10-16"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20211023.md
+++ b/src/content/weekly/dev-weekly-20211023.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-10-23
-date: "2021-10-23T17:00:00.000Z"
+date: "2021-10-23T17:00:00+09:00"
 description: "dev-weekly 2021-10-23"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20211030.md
+++ b/src/content/weekly/dev-weekly-20211030.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-10-30
-date: "2021-10-30T17:00:00.000Z"
+date: "2021-10-30T17:00:00+09:00"
 description: "dev-weekly 2021-10-30"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20211106.md
+++ b/src/content/weekly/dev-weekly-20211106.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-11-06
-date: "2021-11-06T10:00:00.000Z"
+date: "2021-11-06T10:00:00+09:00"
 description: "dev-weekly 2021-11-06"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20211113.md
+++ b/src/content/weekly/dev-weekly-20211113.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-11-13
-date: "2021-11-13T10:00:00.000Z"
+date: "2021-11-13T10:00:00+09:00"
 description: "dev-weekly 2021-11-13"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20211120.md
+++ b/src/content/weekly/dev-weekly-20211120.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-11-20
-date: "2021-11-20T09:00:00.000Z"
+date: "2021-11-20T09:00:00+09:00"
 description: "dev-weekly 2021-11-20"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20211127.md
+++ b/src/content/weekly/dev-weekly-20211127.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-11-27
-date: "2021-11-27T10:00:00.000Z"
+date: "2021-11-27T10:00:00+09:00"
 description: "dev-weekly 2021-11-27"
 tags: ["css", "node", "javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20211204.md
+++ b/src/content/weekly/dev-weekly-20211204.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-12-04
-date: "2021-12-04T10:00:00.000Z"
+date: "2021-12-04T10:00:00+09:00"
 description: "dev-weekly 2021-12-04"
 tags: ["node", "javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20211211.md
+++ b/src/content/weekly/dev-weekly-20211211.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-12-11
-date: "2021-12-11T10:00:00.000Z"
+date: "2021-12-11T10:00:00+09:00"
 description: "dev-weekly 2021-12-11"
 tags: ["css", "node", "javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20211218.md
+++ b/src/content/weekly/dev-weekly-20211218.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-12-18
-date: "2021-12-18T11:00:00.000Z"
+date: "2021-12-18T11:00:00+09:00"
 description: "dev-weekly 2021-12-18"
 tags: ["css", "node", "javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20211225.md
+++ b/src/content/weekly/dev-weekly-20211225.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2021-12-25 - 연말이라 js, node 2주간 쉽니당
-date: "2021-12-25T10:00:00.000Z"
+date: "2021-12-25T10:00:00+09:00"
 description: "dev-weekly 2021-12-25"
 tags: ["css"]
 ---

--- a/src/content/weekly/dev-weekly-20220108.md
+++ b/src/content/weekly/dev-weekly-20220108.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-01-08
-date: "2022-01-08T10:00:00.000Z"
+date: "2022-01-08T10:00:00+09:00"
 description: "dev-weekly 2022-01-08"
 tags: ["js"]
 ---

--- a/src/content/weekly/dev-weekly-20220115.md
+++ b/src/content/weekly/dev-weekly-20220115.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-01-15
-date: "2022-01-15T10:00:00.000Z"
+date: "2022-01-15T10:00:00+09:00"
 description: "dev-weekly 2022-01-15"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20220122.md
+++ b/src/content/weekly/dev-weekly-20220122.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-01-22
-date: "2022-01-22T09:00:00.000Z"
+date: "2022-01-22T09:00:00+09:00"
 description: "dev-weekly 2022-01-22"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20220129.md
+++ b/src/content/weekly/dev-weekly-20220129.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-01-29
-date: "2022-01-29T08:00:00.000Z"
+date: "2022-01-29T08:00:00+09:00"
 description: "dev-weekly 2022-01-29"
 tags: ["javascript", "node", "css", "go"]
 ---

--- a/src/content/weekly/dev-weekly-20220205.md
+++ b/src/content/weekly/dev-weekly-20220205.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-02-05
-date: "2022-02-05T08:30:00.000Z"
+date: "2022-02-05T08:30:00+09:00"
 description: "dev-weekly 2022-02-05"
 tags: ["javascript", "css", "node", "go"]
 ---

--- a/src/content/weekly/dev-weekly-20220212.md
+++ b/src/content/weekly/dev-weekly-20220212.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-02-12
-date: "2022-02-12T08:30:00.000Z"
+date: "2022-02-12T08:30:00+09:00"
 description: "dev-weekly 2022-02-12"
 tags: ["javascript", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20220219.md
+++ b/src/content/weekly/dev-weekly-20220219.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-02-19
-date: "2022-02-19T19:47:00.000Z"
+date: "2022-02-19T19:47:00+09:00"
 description: "dev-weekly 2022-02-19"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20220226.md
+++ b/src/content/weekly/dev-weekly-20220226.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-02-26
-date: "2022-02-26T10:30:00.000Z"
+date: "2022-02-26T10:30:00+09:00"
 description: "dev-weekly 2022-02-26"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20220305.md
+++ b/src/content/weekly/dev-weekly-20220305.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-03-05
-date: "2022-03-05T17:00:00.000Z"
+date: "2022-03-05T17:00:00+09:00"
 description: "dev-weekly 2022-03-05"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20220312.md
+++ b/src/content/weekly/dev-weekly-20220312.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-03-12
-date: "2022-03-12T14:00:00.000Z"
+date: "2022-03-12T14:00:00+09:00"
 description: "dev-weekly 2022-03-12"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20220319.md
+++ b/src/content/weekly/dev-weekly-20220319.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-03-19
-date: "2022-03-19T11:00:00.000Z"
+date: "2022-03-19T11:00:00+09:00"
 description: "dev-weekly 2022-03-19"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20220326.md
+++ b/src/content/weekly/dev-weekly-20220326.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-03-26
-date: "2022-03-26T14:00:00.000Z"
+date: "2022-03-26T14:00:00+09:00"
 description: "dev-weekly 2022-03-26"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20220402.md
+++ b/src/content/weekly/dev-weekly-20220402.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-04-02
-date: "2022-04-02T14:00:00.000Z"
+date: "2022-04-02T14:00:00+09:00"
 description: "dev-weekly 2022-04-02"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20220409.md
+++ b/src/content/weekly/dev-weekly-20220409.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-04-09
-date: "2022-04-09T21:50:00.000Z"
+date: "2022-04-09T21:50:00+09:00"
 description: "dev-weekly 2022-04-09"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20220416.md
+++ b/src/content/weekly/dev-weekly-20220416.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-04-16
-date: "2022-04-16T15:40:00.000Z"
+date: "2022-04-16T15:40:00+09:00"
 description: "dev-weekly 2022-04-16"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20220423.md
+++ b/src/content/weekly/dev-weekly-20220423.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-04-23
-date: "2022-04-23T09:00:00.000Z"
+date: "2022-04-23T09:00:00+09:00"
 description: "dev-weekly 2022-04-23"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20220430.md
+++ b/src/content/weekly/dev-weekly-20220430.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-04-30
-date: "2022-04-30T09:50:00.000Z"
+date: "2022-04-30T09:50:00+09:00"
 description: "dev-weekly 2022-04-30"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20220507.md
+++ b/src/content/weekly/dev-weekly-20220507.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-05-07
-date: "2022-05-07T23:45:00.000Z"
+date: "2022-05-07T23:45:00+09:00"
 description: "dev-weekly 2022-05-07"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20220514.md
+++ b/src/content/weekly/dev-weekly-20220514.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-05-14
-date: "2022-05-14T20:00:00.000Z"
+date: "2022-05-14T20:00:00+09:00"
 description: "dev-weekly 2022-05-14"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20220521.md
+++ b/src/content/weekly/dev-weekly-20220521.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-05-21
-date: "2022-05-21T22:00:00.000Z"
+date: "2022-05-21T22:00:00+09:00"
 description: "dev-weekly 2022-05-21"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20220528.md
+++ b/src/content/weekly/dev-weekly-20220528.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-05-28
-date: "2022-05-28T11:00:00.000Z"
+date: "2022-05-28T11:00:00+09:00"
 description: "dev-weekly 2022-05-28"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20220604.md
+++ b/src/content/weekly/dev-weekly-20220604.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-06-04
-date: "2022-06-04T14:00:00.000Z"
+date: "2022-06-04T14:00:00+09:00"
 description: "dev-weekly 2022-06-04"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20220611.md
+++ b/src/content/weekly/dev-weekly-20220611.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-06-11
-date: "2022-06-11T11:00:00.000Z"
+date: "2022-06-11T11:00:00+09:00"
 description: "dev-weekly 2022-06-11"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20220618.md
+++ b/src/content/weekly/dev-weekly-20220618.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-06-18
-date: "2022-06-18T17:00:00.000Z"
+date: "2022-06-18T17:00:00+09:00"
 description: "dev-weekly 2022-06-18"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20220625.md
+++ b/src/content/weekly/dev-weekly-20220625.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-06-25
-date: "2022-06-25T22:30:00.000Z"
+date: "2022-06-25T22:30:00+09:00"
 description: "dev-weekly 2022-06-25"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20220702.md
+++ b/src/content/weekly/dev-weekly-20220702.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-07-02
-date: "2022-07-02T20:30:00.000Z"
+date: "2022-07-02T20:30:00+09:00"
 description: "dev-weekly 2022-07-02"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20220709.md
+++ b/src/content/weekly/dev-weekly-20220709.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-07-09
-date: "2022-07-09T15:15:00.000Z"
+date: "2022-07-09T15:15:00+09:00"
 description: "dev-weekly 2022-07-09"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20220716.md
+++ b/src/content/weekly/dev-weekly-20220716.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-07-16
-date: "2022-07-16T15:15:00.000Z"
+date: "2022-07-16T15:15:00+09:00"
 description: "dev-weekly 2022-07-16"
 tags: ["javascript", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20220723.md
+++ b/src/content/weekly/dev-weekly-20220723.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-07-23
-date: "2022-07-23T08:00:00.000Z"
+date: "2022-07-23T08:00:00+09:00"
 description: "dev-weekly 2022-07-23"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20220730.md
+++ b/src/content/weekly/dev-weekly-20220730.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-07-30
-date: "2022-07-30T16:00:00.000Z"
+date: "2022-07-30T16:00:00+09:00"
 description: "dev-weekly 2022-07-30"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20220806.md
+++ b/src/content/weekly/dev-weekly-20220806.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-08-06
-date: "2022-08-06T08:00:00.000Z"
+date: "2022-08-06T08:00:00+09:00"
 description: "dev-weekly 2022-08-06"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20220813.md
+++ b/src/content/weekly/dev-weekly-20220813.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-08-13
-date: "2022-08-13T17:00:00.000Z"
+date: "2022-08-13T17:00:00+09:00"
 description: "dev-weekly 2022-08-13"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20220820.md
+++ b/src/content/weekly/dev-weekly-20220820.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-08-20
-date: "2022-08-20T10:00:00.000Z"
+date: "2022-08-20T10:00:00+09:00"
 description: "dev-weekly 2022-08-20"
 tags: ["css"]
 ---

--- a/src/content/weekly/dev-weekly-20220827.md
+++ b/src/content/weekly/dev-weekly-20220827.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-08-27
-date: "2022-08-27T12:00:00.000Z"
+date: "2022-08-27T12:00:00+09:00"
 description: "dev-weekly 2022-08-27"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20220903.md
+++ b/src/content/weekly/dev-weekly-20220903.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-09-03
-date: "2022-09-03T10:20:00.000Z"
+date: "2022-09-03T10:20:00+09:00"
 description: "dev-weekly 2022-09-03"
 tags: ["javascript", "css", "node",]
 ---

--- a/src/content/weekly/dev-weekly-20220910.md
+++ b/src/content/weekly/dev-weekly-20220910.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-09-10
-date: "2022-09-10T23:27:00.000Z"
+date: "2022-09-10T23:27:00+09:00"
 description: "dev-weekly 2022-09-10"
 tags: ["javascript", "css", "node",]
 ---

--- a/src/content/weekly/dev-weekly-20220917.md
+++ b/src/content/weekly/dev-weekly-20220917.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-09-17
-date: "2022-09-17T16:00:00.000Z"
+date: "2022-09-17T16:00:00+09:00"
 description: "dev-weekly 2022-09-17"
 tags: ["javascript", "css", "node",]
 ---

--- a/src/content/weekly/dev-weekly-20220924.md
+++ b/src/content/weekly/dev-weekly-20220924.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-09-24
-date: "2022-09-24T12:30:00.000Z"
+date: "2022-09-24T12:30:00+09:00"
 description: "dev-weekly 2022-09-24"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20221001.md
+++ b/src/content/weekly/dev-weekly-20221001.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-10-01
-date: "2022-10-01T17:00:00.000Z"
+date: "2022-10-01T17:00:00+09:00"
 description: "dev-weekly 2022-10-01"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20221008.md
+++ b/src/content/weekly/dev-weekly-20221008.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-10-08
-date: "2022-10-08T18:00:00.000Z"
+date: "2022-10-08T18:00:00+09:00"
 description: "dev-weekly 2022-10-08"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20221015.md
+++ b/src/content/weekly/dev-weekly-20221015.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-10-15
-date: "2022-10-15T22:00:00.000Z"
+date: "2022-10-15T22:00:00+09:00"
 description: "dev-weekly 2022-10-15"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20221022.md
+++ b/src/content/weekly/dev-weekly-20221022.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-10-22
-date: "2022-10-22T11:00:00.000Z"
+date: "2022-10-22T11:00:00+09:00"
 description: "dev-weekly 2022-10-22"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20221029.md
+++ b/src/content/weekly/dev-weekly-20221029.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-10-29
-date: "2022-10-29T11:00:00.000Z"
+date: "2022-10-29T11:00:00+09:00"
 description: "dev-weekly 2022-10-29"
 tags: ["javascript", "css", "node", "devtool"]
 ---

--- a/src/content/weekly/dev-weekly-20221105.md
+++ b/src/content/weekly/dev-weekly-20221105.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-11-05
-date: "2022-11-05T14:00:00.000Z"
+date: "2022-11-05T14:00:00+09:00"
 description: "dev-weekly 2022-11-05"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20221112.md
+++ b/src/content/weekly/dev-weekly-20221112.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-11-12
-date: "2022-11-12T17:00:00.000Z"
+date: "2022-11-12T17:00:00+09:00"
 description: "dev-weekly 2022-11-12"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20221119.md
+++ b/src/content/weekly/dev-weekly-20221119.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-11-19
-date: "2022-11-19T12:00:00.000Z"
+date: "2022-11-19T12:00:00+09:00"
 description: "dev-weekly 2022-11-19"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20221126.md
+++ b/src/content/weekly/dev-weekly-20221126.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-11-26
-date: "2022-11-26T11:50:00.000Z"
+date: "2022-11-26T11:50:00+09:00"
 description: "dev-weekly 2022-11-26"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20221203.md
+++ b/src/content/weekly/dev-weekly-20221203.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-12-03
-date: "2022-12-03T19:30:00.000Z"
+date: "2022-12-03T19:30:00+09:00"
 description: "dev-weekly 2022-12-03"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20221210.md
+++ b/src/content/weekly/dev-weekly-20221210.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-12-10
-date: "2022-12-10T19:30:00.000Z"
+date: "2022-12-10T19:30:00+09:00"
 description: "dev-weekly 2022-12-10"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20221217.md
+++ b/src/content/weekly/dev-weekly-20221217.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2022-12-17
-date: "2022-12-17T10:40:00.000Z"
+date: "2022-12-17T10:40:00+09:00"
 description: "dev-weekly 2022-12-17"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20230107.md
+++ b/src/content/weekly/dev-weekly-20230107.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-01-07
-date: "2023-01-07T13:00:00.000Z"
+date: "2023-01-07T13:00:00+09:00"
 description: "dev-weekly 2023-01-07"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20230114.md
+++ b/src/content/weekly/dev-weekly-20230114.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-01-14
-date: "2023-01-14T16:20:00.000Z"
+date: "2023-01-14T16:20:00+09:00"
 description: "dev-weekly 2023-01-14"
 tags: ["javascript", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20230121.md
+++ b/src/content/weekly/dev-weekly-20230121.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-01-21
-date: "2023-01-21T15:20:00.000Z"
+date: "2023-01-21T15:20:00+09:00"
 description: "dev-weekly 2023-01-21"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20230128.md
+++ b/src/content/weekly/dev-weekly-20230128.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-01-28
-date: "2023-01-28T12:10:00.000Z"
+date: "2023-01-28T12:10:00+09:00"
 description: "dev-weekly 2023-01-28"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20230204.md
+++ b/src/content/weekly/dev-weekly-20230204.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-02-04
-date: "2023-02-04T12:20:00.000Z"
+date: "2023-02-04T12:20:00+09:00"
 description: "dev-weekly 2023-02-04"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20230211.md
+++ b/src/content/weekly/dev-weekly-20230211.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-02-11
-date: "2023-02-11T17:20:00.000Z"
+date: "2023-02-11T17:20:00+09:00"
 description: "dev-weekly 2023-02-11"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20230218.md
+++ b/src/content/weekly/dev-weekly-20230218.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-02-18
-date: "2023-02-18T12:40:00.000Z"
+date: "2023-02-18T12:40:00+09:00"
 description: "dev-weekly 2023-02-18"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20230225.md
+++ b/src/content/weekly/dev-weekly-20230225.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-02-25
-date: "2023-02-25T14:00:00.000Z"
+date: "2023-02-25T14:00:00+09:00"
 description: "dev-weekly 2023-02-25"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20230304.md
+++ b/src/content/weekly/dev-weekly-20230304.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-03-04
-date: "2023-03-04T14:00:00.000Z"
+date: "2023-03-04T14:00:00+09:00"
 description: "dev-weekly 2023-03-04"
 tags: ["javascript", "css", "node", "etc"]
 ---

--- a/src/content/weekly/dev-weekly-20230311.md
+++ b/src/content/weekly/dev-weekly-20230311.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-03-11
-date: "2023-03-11T11:30:00.000Z"
+date: "2023-03-11T11:30:00+09:00"
 description: "dev-weekly 2023-03-11"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20230318.md
+++ b/src/content/weekly/dev-weekly-20230318.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-03-18
-date: "2023-03-18T12:40:00.000Z"
+date: "2023-03-18T12:40:00+09:00"
 description: "dev-weekly 2023-03-18"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20230325.md
+++ b/src/content/weekly/dev-weekly-20230325.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-03-25
-date: "2023-03-25T12:00:00.000Z"
+date: "2023-03-25T12:00:00+09:00"
 description: "dev-weekly 2023-03-25"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20230401.md
+++ b/src/content/weekly/dev-weekly-20230401.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-04-01
-date: "2023-04-01T14:40:00.000Z"
+date: "2023-04-01T14:40:00+09:00"
 description: "dev-weekly 2023-04-01"
 tags: ["javascript", "css", "node", "web", "typescript"]
 ---

--- a/src/content/weekly/dev-weekly-20230408.md
+++ b/src/content/weekly/dev-weekly-20230408.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-04-08
-date: "2023-04-08T14:40:00.000Z"
+date: "2023-04-08T14:40:00+09:00"
 description: "dev-weekly 2023-04-08"
 tags: ["javascript", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20230415.md
+++ b/src/content/weekly/dev-weekly-20230415.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-04-15
-date: "2023-04-15T11:00:00.000Z"
+date: "2023-04-15T11:00:00+09:00"
 description: "dev-weekly 2023-04-15"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20230422.md
+++ b/src/content/weekly/dev-weekly-20230422.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-04-22
-date: "2023-04-22T10:00:00.000Z"
+date: "2023-04-22T10:00:00+09:00"
 description: "dev-weekly 2023-04-22"
 tags: ["javascript", "css", "node", "infra", "etc"]
 ---

--- a/src/content/weekly/dev-weekly-20230429.md
+++ b/src/content/weekly/dev-weekly-20230429.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-04-29
-date: "2023-04-29T12:30:00.000Z"
+date: "2023-04-29T12:30:00+09:00"
 description: "dev-weekly 2023-04-29"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20230505.md
+++ b/src/content/weekly/dev-weekly-20230505.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-05-05
-date: "2023-05-05T17:00:00.000Z"
+date: "2023-05-05T17:00:00+09:00"
 description: "dev-weekly 2023-05-05"
 tags: ["javascript", "css", "node", "etc"]
 ---

--- a/src/content/weekly/dev-weekly-20230513.md
+++ b/src/content/weekly/dev-weekly-20230513.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-05-13
-date: "2023-05-13T12:40:00.000Z"
+date: "2023-05-13T12:40:00+09:00"
 description: "dev-weekly 2023-05-13"
 tags: ["javascript", "css", "node", "etc"]
 ---

--- a/src/content/weekly/dev-weekly-20230520.md
+++ b/src/content/weekly/dev-weekly-20230520.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-05-20
-date: "2023-05-20T09:00:00.000Z"
+date: "2023-05-20T09:00:00+09:00"
 description: "dev-weekly 2023-05-20"
 tags: ["javascript", "css", "node", "etc"]
 ---

--- a/src/content/weekly/dev-weekly-20230527.md
+++ b/src/content/weekly/dev-weekly-20230527.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-05-27
-date: "2023-05-27T12:00:00.000Z"
+date: "2023-05-27T12:00:00+09:00"
 description: "dev-weekly 2023-05-27"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20230602.md
+++ b/src/content/weekly/dev-weekly-20230602.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-06-02
-date: "2023-06-02T23:50:00.000Z"
+date: "2023-06-02T23:50:00+09:00"
 description: "dev-weekly 2023-06-02"
 tags: ["javascript", "css", "node", "go", "etc"]
 ---

--- a/src/content/weekly/dev-weekly-20230610.md
+++ b/src/content/weekly/dev-weekly-20230610.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-06-10
-date: "2023-06-10T11:00:00.000Z"
+date: "2023-06-10T11:00:00+09:00"
 description: "dev-weekly 2023-06-10"
 tags: ["javascript", "css", "node", "etc"]
 ---

--- a/src/content/weekly/dev-weekly-20230617.md
+++ b/src/content/weekly/dev-weekly-20230617.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-06-17
-date: "2023-06-17T16:10:00.000Z"
+date: "2023-06-17T16:10:00+09:00"
 description: "dev-weekly 2023-06-17"
 tags: ["javascript", "css", "node", "go", "etc"]
 ---

--- a/src/content/weekly/dev-weekly-20230624.md
+++ b/src/content/weekly/dev-weekly-20230624.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-06-24
-date: "2023-06-24T12:00:00.000Z"
+date: "2023-06-24T12:00:00+09:00"
 description: "dev-weekly 2023-06-24"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20230630.md
+++ b/src/content/weekly/dev-weekly-20230630.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-06-30
-date: "2023-06-30T12:40:00.000Z"
+date: "2023-06-30T12:40:00+09:00"
 description: "dev-weekly 2023-06-30"
 tags: ["javascript", "css", "node", "etc"]
 ---

--- a/src/content/weekly/dev-weekly-20230708.md
+++ b/src/content/weekly/dev-weekly-20230708.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-07-08
-date: "2023-07-08T15:55:00.000Z"
+date: "2023-07-08T15:55:00+09:00"
 description: "dev-weekly 2023-07-08"
 tags: ["javascript", "css", "node", "etc"]
 ---

--- a/src/content/weekly/dev-weekly-20230715.md
+++ b/src/content/weekly/dev-weekly-20230715.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-07-15
-date: "2023-07-15T15:15:00.000Z"
+date: "2023-07-15T15:15:00+09:00"
 description: "dev-weekly 2023-07-15"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20230722.md
+++ b/src/content/weekly/dev-weekly-20230722.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-07-22
-date: "2023-07-22T09:00:00.000Z"
+date: "2023-07-22T09:00:00+09:00"
 description: "dev-weekly 2023-07-22"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20230729.md
+++ b/src/content/weekly/dev-weekly-20230729.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-07-29
-date: "2023-07-29T16:30:00.000Z"
+date: "2023-07-29T16:30:00+09:00"
 description: "dev-weekly 2023-07-29"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20230805.md
+++ b/src/content/weekly/dev-weekly-20230805.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-08-05
-date: "2023-08-05T16:00:00.000Z"
+date: "2023-08-05T16:00:00+09:00"
 description: "dev-weekly 2023-08-05"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20230812.md
+++ b/src/content/weekly/dev-weekly-20230812.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-08-12
-date: "2023-08-12T11:30:00.000Z"
+date: "2023-08-12T11:30:00+09:00"
 description: "dev-weekly 2023-08-12"
 tags: ["javascript", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20230819.md
+++ b/src/content/weekly/dev-weekly-20230819.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-08-19
-date: "2023-08-19T17:35:00.000Z"
+date: "2023-08-19T17:35:00+09:00"
 description: "dev-weekly 2023-08-19"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20230902.md
+++ b/src/content/weekly/dev-weekly-20230902.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-09-02
-date: "2023-09-02T11:40:00.000Z"
+date: "2023-09-02T11:40:00+09:00"
 description: "dev-weekly 2023-09-02"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20230909.md
+++ b/src/content/weekly/dev-weekly-20230909.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-09-09
-date: "2023-09-09T11:30:00.000Z"
+date: "2023-09-09T11:30:00+09:00"
 description: "dev-weekly 2023-09-09"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20230916.md
+++ b/src/content/weekly/dev-weekly-20230916.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-09-16
-date: "2023-09-16T21:16:00.000Z"
+date: "2023-09-16T21:16:00+09:00"
 description: "dev-weekly 2023-09-16"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20230923.md
+++ b/src/content/weekly/dev-weekly-20230923.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-09-23
-date: "2023-09-23T10:45:00.000Z"
+date: "2023-09-23T10:45:00+09:00"
 description: "dev-weekly 2023-09-23"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20230930.md
+++ b/src/content/weekly/dev-weekly-20230930.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-09-30
-date: "2023-09-30T11:35:00.000Z"
+date: "2023-09-30T11:35:00+09:00"
 description: "dev-weekly 2023-09-30"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20231007.md
+++ b/src/content/weekly/dev-weekly-20231007.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-10-07
-date: "2023-10-07T10:40:00.000Z"
+date: "2023-10-07T10:40:00+09:00"
 description: "dev-weekly 2023-10-07"
 tags: ["javascript", "node", "browser"]
 ---

--- a/src/content/weekly/dev-weekly-20231014.md
+++ b/src/content/weekly/dev-weekly-20231014.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-10-14
-date: "2023-10-14T11:00:00.000Z"
+date: "2023-10-14T11:00:00+09:00"
 description: "dev-weekly 2023-10-14"
 tags: ["javascript", "CSS", "node", "v8", "ddos"]
 ---

--- a/src/content/weekly/dev-weekly-20231021.md
+++ b/src/content/weekly/dev-weekly-20231021.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-10-21
-date: "2023-10-21T13:10:00.000Z"
+date: "2023-10-21T13:10:00+09:00"
 description: "dev-weekly 2023-10-21"
 tags: ["javascript", "CSS", "node", "unicode"]
 ---

--- a/src/content/weekly/dev-weekly-20231028.md
+++ b/src/content/weekly/dev-weekly-20231028.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-10-28
-date: "2023-10-28T09:50:00.000Z"
+date: "2023-10-28T09:50:00+09:00"
 description: "dev-weekly 2023-10-28"
 tags: ["javascript", "CSS", "node", "eslint"]
 ---

--- a/src/content/weekly/dev-weekly-20231104.md
+++ b/src/content/weekly/dev-weekly-20231104.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-11-04
-date: "2023-11-04T11:20:00.000Z"
+date: "2023-11-04T11:20:00+09:00"
 description: "dev-weekly 2023-11-04"
 tags: ["javascript", "CSS", "node", "browser"]
 ---

--- a/src/content/weekly/dev-weekly-20231111.md
+++ b/src/content/weekly/dev-weekly-20231111.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-11-11
-date: "2023-11-11T11:20:00.000Z"
+date: "2023-11-11T11:20:00+09:00"
 description: "dev-weekly 2023-11-11"
 tags: ["javascript", "CSS", "node", "eslint"]
 ---

--- a/src/content/weekly/dev-weekly-20231118.md
+++ b/src/content/weekly/dev-weekly-20231118.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-11-18
-date: "2023-11-18T15:45:00.000Z"
+date: "2023-11-18T15:45:00+09:00"
 description: "dev-weekly 2023-11-18"
 tags: ["javascript", "CSS", "node", "v8"]
 ---

--- a/src/content/weekly/dev-weekly-20231125.md
+++ b/src/content/weekly/dev-weekly-20231125.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-11-25
-date: "2023-11-25T14:50:00.000Z"
+date: "2023-11-25T14:50:00+09:00"
 description: "dev-weekly 2023-11-25"
 tags: ["javascript", "CSS", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20231202.md
+++ b/src/content/weekly/dev-weekly-20231202.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-12-02
-date: "2023-12-02T11:10:00.000Z"
+date: "2023-12-02T11:10:00+09:00"
 description: "dev-weekly 2023-12-02"
 tags: ["javascript", "CSS", "node", "WASM"]
 ---

--- a/src/content/weekly/dev-weekly-20231209.md
+++ b/src/content/weekly/dev-weekly-20231209.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-12-09
-date: "2023-12-09T18:38:00.000Z"
+date: "2023-12-09T18:38:00+09:00"
 description: "dev-weekly 2023-12-09"
 tags: ["javascript", "CSS", "node", "a11y", "v8"]
 ---

--- a/src/content/weekly/dev-weekly-20231216.md
+++ b/src/content/weekly/dev-weekly-20231216.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-12-16
-date: "2023-12-16T16:21:00.000Z"
+date: "2023-12-16T16:21:00+09:00"
 description: "dev-weekly 2023-12-16"
 tags: ["javascript", "CSS", "node", "vscode", "browser"]
 ---

--- a/src/content/weekly/dev-weekly-20231223.md
+++ b/src/content/weekly/dev-weekly-20231223.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2023-12-23
-date: "2023-12-23T17:10:00.000Z"
+date: "2023-12-23T17:10:00+09:00"
 description: "dev-weekly 2023-12-23"
 tags: ["javascript", "CSS", "browser", "v8"]
 ---

--- a/src/content/weekly/dev-weekly-20240106.md
+++ b/src/content/weekly/dev-weekly-20240106.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-01-06
-date: "2024-01-06T13:20:00.000Z"
+date: "2024-01-06T13:20:00+09:00"
 description: "dev-weekly 2024-01-06"
 tags: ["javascript", "typescript"]
 ---

--- a/src/content/weekly/dev-weekly-20240113.md
+++ b/src/content/weekly/dev-weekly-20240113.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-01-13
-date: "2024-01-13T10:40:00.000Z"
+date: "2024-01-13T10:40:00+09:00"
 description: "dev-weekly 2024-01-13"
 tags: ["javascript", "CSS", "a11y", "node", "Benchmark"]
 ---

--- a/src/content/weekly/dev-weekly-20240120.md
+++ b/src/content/weekly/dev-weekly-20240120.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-01-20
-date: "2024-01-20T13:30:00.000Z"
+date: "2024-01-20T13:30:00+09:00"
 description: "dev-weekly 2024-01-20"
 tags: ["javascript", "CSS", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20240127.md
+++ b/src/content/weekly/dev-weekly-20240127.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-01-27
-date: "2024-01-27T12:00:00.000Z"
+date: "2024-01-27T12:00:00+09:00"
 description: "dev-weekly 2024-01-27"
 tags: ["javascript", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20240203.md
+++ b/src/content/weekly/dev-weekly-20240203.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-02-03
-date: "2024-02-03T10:40:00.000Z"
+date: "2024-02-03T10:40:00+09:00"
 description: "dev-weekly 2024-02-03"
 tags: ["javascript", "node", "css", "deno"]
 ---

--- a/src/content/weekly/dev-weekly-20240210.md
+++ b/src/content/weekly/dev-weekly-20240210.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-02-10
-date: "2024-02-10T11:30:00.000Z"
+date: "2024-02-10T11:30:00+09:00"
 description: "dev-weekly 2024-02-10"
 tags: ["javascript", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20240217.md
+++ b/src/content/weekly/dev-weekly-20240217.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-02-17
-date: "2024-02-17T20:00:00.000Z"
+date: "2024-02-17T20:00:00+09:00"
 description: "dev-weekly 2024-02-17"
 tags: ["javascript", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20240224.md
+++ b/src/content/weekly/dev-weekly-20240224.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-02-24
-date: "2024-02-24T17:00:00.000Z"
+date: "2024-02-24T17:00:00+09:00"
 description: "dev-weekly 2024-02-24"
 tags: ["javascript", "css", "chrome", "ai"]
 ---

--- a/src/content/weekly/dev-weekly-20240302.md
+++ b/src/content/weekly/dev-weekly-20240302.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-03-02
-date: "2024-03-02T11:10:00.000Z"
+date: "2024-03-02T11:10:00+09:00"
 description: "dev-weekly 2024-03-02"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20240309.md
+++ b/src/content/weekly/dev-weekly-20240309.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-03-09
-date: "2024-03-09T19:00:00.000Z"
+date: "2024-03-09T19:00:00+09:00"
 description: "dev-weekly 2024-03-09"
 tags: ["javascript", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20240316.md
+++ b/src/content/weekly/dev-weekly-20240316.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-03-16
-date: "2024-03-16T10:00:00.000Z"
+date: "2024-03-16T10:00:00+09:00"
 description: "dev-weekly 2024-03-16"
 tags: ["javascript", "node", "css", "ai", "github"]
 ---

--- a/src/content/weekly/dev-weekly-20240323.md
+++ b/src/content/weekly/dev-weekly-20240323.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-03-23
-date: "2024-03-23T20:00:00.000Z"
+date: "2024-03-23T20:00:00+09:00"
 description: "dev-weekly 2024-03-23"
 tags: ["javascript", "node", "css", "w3c"]
 ---

--- a/src/content/weekly/dev-weekly-20240330.md
+++ b/src/content/weekly/dev-weekly-20240330.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-03-30
-date: "2024-03-30T22:55:00.000Z"
+date: "2024-03-30T22:55:00+09:00"
 description: "dev-weekly 2024-03-30"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20240405.md
+++ b/src/content/weekly/dev-weekly-20240405.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-04-05
-date: "2025-04-05T18:01:00.000Z"
+date: "2025-04-05T18:01:00+09:00"
 description: "dev-weekly 2025-04-05"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20240406.md
+++ b/src/content/weekly/dev-weekly-20240406.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-04-06
-date: "2024-04-06T20:30:00.000Z"
+date: "2024-04-06T20:30:00+09:00"
 description: "dev-weekly 2024-04-06"
 tags: ["javascript", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20240413.md
+++ b/src/content/weekly/dev-weekly-20240413.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-04-13
-date: "2024-04-13T16:15:00.000Z"
+date: "2024-04-13T16:15:00+09:00"
 description: "dev-weekly 2024-04-13"
 tags: ["javascript", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20240420.md
+++ b/src/content/weekly/dev-weekly-20240420.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-04-20
-date: "2024-04-20T23:15:00.000Z"
+date: "2024-04-20T23:15:00+09:00"
 description: "dev-weekly 2024-04-20"
 tags: ["javascript", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20240427.md
+++ b/src/content/weekly/dev-weekly-20240427.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-04-27
-date: "2024-04-27T15:00:00.000Z"
+date: "2024-04-27T15:00:00+09:00"
 description: "dev-weekly 2024-04-27"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20240504.md
+++ b/src/content/weekly/dev-weekly-20240504.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-05-04
-date: "2024-05-04T15:00:00.000Z"
+date: "2024-05-04T15:00:00+09:00"
 description: "dev-weekly 2024-05-04"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20240511.md
+++ b/src/content/weekly/dev-weekly-20240511.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-05-11
-date: "2024-05-11T14:20:00.000Z"
+date: "2024-05-11T14:20:00+09:00"
 description: "dev-weekly 2024-05-11"
 tags: ["javascript", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20240518.md
+++ b/src/content/weekly/dev-weekly-20240518.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-05-18
-date: "2024-05-18T15:00:00.000Z"
+date: "2024-05-18T15:00:00+09:00"
 description: "dev-weekly 2024-05-18"
 tags: ["javascript", "node", "css", "chrome"]
 ---

--- a/src/content/weekly/dev-weekly-20240525.md
+++ b/src/content/weekly/dev-weekly-20240525.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-05-25
-date: "2024-05-25T16:45:00.000Z"
+date: "2024-05-25T16:45:00+09:00"
 description: "dev-weekly 2024-05-25"
 tags: ["javascript", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20240531.md
+++ b/src/content/weekly/dev-weekly-20240531.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-05-31
-date: "2025-05-31T21:54:00.000Z"
+date: "2025-05-31T21:54:00+09:00"
 description: "dev-weekly 2025-05-31"
 tags: ["node","css", "javascript", "chrome"]
 ---

--- a/src/content/weekly/dev-weekly-20240601.md
+++ b/src/content/weekly/dev-weekly-20240601.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-06-01
-date: "2024-06-01T20:48:00.000Z"
+date: "2024-06-01T20:48:00+09:00"
 description: "dev-weekly 2024-06-01"
 tags: ["javascript", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20240608.md
+++ b/src/content/weekly/dev-weekly-20240608.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-06-08
-date: "2024-06-08T12:10:00.000Z"
+date: "2024-06-08T12:10:00+09:00"
 description: "dev-weekly 2024-06-08"
 tags: ["javascript", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20240615.md
+++ b/src/content/weekly/dev-weekly-20240615.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-06-15
-date: "2024-06-15T17:38:00.000Z"
+date: "2024-06-15T17:38:00+09:00"
 description: "dev-weekly 2024-06-15"
 tags: ["css", "browser"]
 ---

--- a/src/content/weekly/dev-weekly-20240622.md
+++ b/src/content/weekly/dev-weekly-20240622.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-06-22
-date: "2024-06-22T18:15:00.000Z"
+date: "2024-06-22T18:15:00+09:00"
 description: "dev-weekly 2024-06-22"
 tags: ["css", "node", "javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20240629.md
+++ b/src/content/weekly/dev-weekly-20240629.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-06-29
-date: "2024-06-29T17:30:00.000Z"
+date: "2024-06-29T17:30:00+09:00"
 description: "dev-weekly 2024-06-29"
 tags: ["css", "javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20240706.md
+++ b/src/content/weekly/dev-weekly-20240706.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-07-06
-date: "2024-07-06T18:15:00.000Z"
+date: "2024-07-06T18:15:00+09:00"
 description: "dev-weekly 2024-07-06"
 tags: ["css", "javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20240713.md
+++ b/src/content/weekly/dev-weekly-20240713.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-07-13
-date: "2024-07-13T16:58:00.000Z"
+date: "2024-07-13T16:58:00+09:00"
 description: "dev-weekly 2024-07-13"
 tags: ["css", "node", "javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20240720.md
+++ b/src/content/weekly/dev-weekly-20240720.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-07-20
-date: "2024-07-20T14:47:00.000Z"
+date: "2024-07-20T14:47:00+09:00"
 description: "dev-weekly 2024-07-20"
 tags: ["node", "javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20240727.md
+++ b/src/content/weekly/dev-weekly-20240727.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-07-27
-date: "2024-07-27T15:09:00.000Z"
+date: "2024-07-27T15:09:00+09:00"
 description: "dev-weekly 2024-07-27"
 tags: ["node", "javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20240803.md
+++ b/src/content/weekly/dev-weekly-20240803.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-08-03
-date: "2024-08-03T14:08:00.000Z"
+date: "2024-08-03T14:08:00+09:00"
 description: "dev-weekly 2024-08-03"
 tags: ["css", "javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20240810.md
+++ b/src/content/weekly/dev-weekly-20240810.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-08-10
-date: "2024-08-10T16:13:00.000Z"
+date: "2024-08-10T16:13:00+09:00"
 description: "dev-weekly 2024-08-10"
 tags: ["css", "javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20240817.md
+++ b/src/content/weekly/dev-weekly-20240817.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-08-17
-date: "2024-08-17T17:30:00.000Z"
+date: "2024-08-17T17:30:00+09:00"
 description: "dev-weekly 2024-08-17"
 tags: ["node", "npm", "javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20240824.md
+++ b/src/content/weekly/dev-weekly-20240824.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-08-24
-date: "2024-08-24T20:45:00.000Z"
+date: "2024-08-24T20:45:00+09:00"
 description: "dev-weekly 2024-08-24"
 tags: ["css", "node", "javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20240831.md
+++ b/src/content/weekly/dev-weekly-20240831.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-08-31
-date: "2024-08-31T19:19:00.000Z"
+date: "2024-08-31T19:19:00+09:00"
 description: "dev-weekly 2024-08-31"
 tags: ["css", "node", "javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20240907.md
+++ b/src/content/weekly/dev-weekly-20240907.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-09-07
-date: "2024-09-07T22:53:00.000Z"
+date: "2024-09-07T22:53:00+09:00"
 description: "dev-weekly 2024-09-07"
 tags: ["css", "node", "javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20240914.md
+++ b/src/content/weekly/dev-weekly-20240914.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-09-14
-date: "2024-09-14T22:16:00.000Z"
+date: "2024-09-14T22:16:00+09:00"
 description: "dev-weekly 2024-09-14"
 tags: ["css", "node", "javascript", "clipboard"]
 ---

--- a/src/content/weekly/dev-weekly-20240921.md
+++ b/src/content/weekly/dev-weekly-20240921.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-09-21
-date: "2024-09-21T13:45:00.000Z"
+date: "2024-09-21T13:45:00+09:00"
 description: "dev-weekly 2024-09-21"
 tags: ["css", "node", "javascript", "clipboard"]
 ---

--- a/src/content/weekly/dev-weekly-20240928.md
+++ b/src/content/weekly/dev-weekly-20240928.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-09-28
-date: "2024-09-28T18:54:00.000Z"
+date: "2024-09-28T18:54:00+09:00"
 description: "dev-weekly 2024-09-28"
 tags: ["css", "node", "javascript", "performance"]
 ---

--- a/src/content/weekly/dev-weekly-20241005.md
+++ b/src/content/weekly/dev-weekly-20241005.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-10-05
-date: "2024-10-05T10:40:00.000Z"
+date: "2024-10-05T10:40:00+09:00"
 description: "dev-weekly 2024-10-05"
 tags: ["javascript", "CSS", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20241012.md
+++ b/src/content/weekly/dev-weekly-20241012.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-10-12
-date: "2024-10-12T17:29:00.000Z"
+date: "2024-10-12T17:29:00+09:00"
 description: "dev-weekly 2024-10-12"
 tags: ["javascript", "CSS", "js13kgames"]
 ---

--- a/src/content/weekly/dev-weekly-20241019.md
+++ b/src/content/weekly/dev-weekly-20241019.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-10-19
-date: "2024-10-19T20:45:00.000Z"
+date: "2024-10-19T20:45:00+09:00"
 description: "dev-weekly 2024-10-19"
 tags: ["javascript", "CSS", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20241026.md
+++ b/src/content/weekly/dev-weekly-20241026.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-10-26
-date: "2024-10-26T13:25:00.000Z"
+date: "2024-10-26T13:25:00+09:00"
 description: "dev-weekly 2024-10-26"
 tags: ["javascript", "ai", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20241102.md
+++ b/src/content/weekly/dev-weekly-20241102.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-11-02
-date: "2024-11-02T16:20:00.000Z"
+date: "2024-11-02T16:20:00+09:00"
 description: "dev-weekly 2024-11-02"
 tags: ["javascript", "vscode", "node", "browser", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20241109.md
+++ b/src/content/weekly/dev-weekly-20241109.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-11-09
-date: "2024-11-09T19:08:00.000Z"
+date: "2024-11-09T19:08:00+09:00"
 description: "dev-weekly 2024-11-09"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20241116.md
+++ b/src/content/weekly/dev-weekly-20241116.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-11-16
-date: "2024-11-16T16:07:00.000Z"
+date: "2024-11-16T16:07:00+09:00"
 description: "dev-weekly 2024-11-16"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20241123.md
+++ b/src/content/weekly/dev-weekly-20241123.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-11-23
-date: "2024-11-23T13:59:00.000Z"
+date: "2024-11-23T13:59:00+09:00"
 description: "dev-weekly 2024-11-23"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20241130.md
+++ b/src/content/weekly/dev-weekly-20241130.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-11-30
-date: "2024-11-30T15:20:00.000Z"
+date: "2024-11-30T15:20:00+09:00"
 description: "dev-weekly 2024-11-30"
 tags: ["javascript", "node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20241207.md
+++ b/src/content/weekly/dev-weekly-20241207.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-12-07
-date: "2024-12-07T22:51:00.000Z"
+date: "2024-12-07T22:51:00+09:00"
 description: "dev-weekly 2024-12-07"
 tags: ["javascript", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20241214.md
+++ b/src/content/weekly/dev-weekly-20241214.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-12-14
-date: "2024-12-14T23:19:00.000Z"
+date: "2024-12-14T23:19:00+09:00"
 description: "dev-weekly 2024-12-14"
 tags: ["javascript", "node", "react", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20241221.md
+++ b/src/content/weekly/dev-weekly-20241221.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2024-12-21
-date: "2024-12-21T19:30:00.000Z"
+date: "2024-12-21T19:30:00+09:00"
 description: "dev-weekly 2024-12-21"
 tags: ["node", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20250111.md
+++ b/src/content/weekly/dev-weekly-20250111.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-01-11
-date: "2025-01-11T17:10:00.000Z"
+date: "2025-01-11T17:10:00+09:00"
 description: "dev-weekly 2025-01-11"
 tags: ["node", "javascript", "vscode"]
 ---

--- a/src/content/weekly/dev-weekly-20250118.md
+++ b/src/content/weekly/dev-weekly-20250118.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-01-18
-date: "2025-01-18T18:09:00.000Z"
+date: "2025-01-18T18:09:00+09:00"
 description: "dev-weekly 2025-01-18"
 tags: ["css", "javascript", "browser"]
 ---

--- a/src/content/weekly/dev-weekly-20250125.md
+++ b/src/content/weekly/dev-weekly-20250125.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-01-25
-date: "2025-01-25T18:35:00.000Z"
+date: "2025-01-25T18:35:00+09:00"
 description: "dev-weekly 2025-01-25"
 tags: ["css", "javascript", "node", "bun", "browser"]
 ---

--- a/src/content/weekly/dev-weekly-20250201.md
+++ b/src/content/weekly/dev-weekly-20250201.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-02-01
-date: "2025-02-01T13:39:00.000Z"
+date: "2025-02-01T13:39:00+09:00"
 description: "dev-weekly 2025-02-01"
 tags: ["javascript", "node", "wasm"]
 ---

--- a/src/content/weekly/dev-weekly-20250208.md
+++ b/src/content/weekly/dev-weekly-20250208.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-02-08
-date: "2025-02-08T15:10:00.000Z"
+date: "2025-02-08T15:10:00+09:00"
 description: "dev-weekly 2025-02-08"
 tags: ["css", "javascript", "node", "deno"]
 ---

--- a/src/content/weekly/dev-weekly-20250215.md
+++ b/src/content/weekly/dev-weekly-20250215.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-02-15
-date: "2025-02-15T15:55:00.000Z"
+date: "2025-02-15T15:55:00+09:00"
 description: "dev-weekly 2025-02-15"
 tags: ["javascript", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20250222.md
+++ b/src/content/weekly/dev-weekly-20250222.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-02-22
-date: "2025-02-22T21:54:00.000Z"
+date: "2025-02-22T21:54:00+09:00"
 description: "dev-weekly 2025-02-22"
 tags: ["javascript", "deno"]
 ---

--- a/src/content/weekly/dev-weekly-20250301.md
+++ b/src/content/weekly/dev-weekly-20250301.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-03-01
-date: "2025-03-01T17:20:00.000Z"
+date: "2025-03-01T17:20:00+09:00"
 description: "dev-weekly 2025-03-01"
 tags: ["javascript", "node", "ai", "browser"]
 ---

--- a/src/content/weekly/dev-weekly-20250308.md
+++ b/src/content/weekly/dev-weekly-20250308.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-03-08
-date: "2025-03-08T12:19:00.000Z"
+date: "2025-03-08T12:19:00+09:00"
 description: "dev-weekly 2025-03-08"
 tags: ["javascript", "node", "ai", "browser"]
 ---

--- a/src/content/weekly/dev-weekly-20250315.md
+++ b/src/content/weekly/dev-weekly-20250315.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-03-15
-date: "2025-03-15T22:32:00.000Z"
+date: "2025-03-15T22:32:00+09:00"
 description: "dev-weekly 2025-03-15"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20250322.md
+++ b/src/content/weekly/dev-weekly-20250322.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-03-22
-date: "2025-03-22T22:36:00.000Z"
+date: "2025-03-22T22:36:00+09:00"
 description: "dev-weekly 2025-03-22"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20250329.md
+++ b/src/content/weekly/dev-weekly-20250329.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-03-29
-date: "2025-03-29T15:24:00.000Z"
+date: "2025-03-29T15:24:00+09:00"
 description: "dev-weekly 2025-03-29"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20250412.md
+++ b/src/content/weekly/dev-weekly-20250412.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-04-12
-date: "2025-04-12T21:20:00.000Z"
+date: "2025-04-12T21:20:00+09:00"
 description: "dev-weekly 2025-04-12"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20250419.md
+++ b/src/content/weekly/dev-weekly-20250419.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-04-19
-date: "2025-04-19T21:29:00.000Z"
+date: "2025-04-19T21:29:00+09:00"
 description: "dev-weekly 2025-04-19"
 tags: ["javascript", "css", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20250426.md
+++ b/src/content/weekly/dev-weekly-20250426.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-04-26
-date: "2025-04-26T23:40:00.000Z"
+date: "2025-04-26T23:40:00+09:00"
 description: "dev-weekly 2025-04-26"
 tags: ["frontend", "node"]
 ---

--- a/src/content/weekly/dev-weekly-20250503.md
+++ b/src/content/weekly/dev-weekly-20250503.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-05-03
-date: "2025-05-03T17:32:00.000Z"
+date: "2025-05-03T17:32:00+09:00"
 description: "dev-weekly 2025-05-03"
 tags: ["javascript","frontend", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20250510.md
+++ b/src/content/weekly/dev-weekly-20250510.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-05-10
-date: "2025-05-10T18:25:00.000Z"
+date: "2025-05-10T18:25:00+09:00"
 description: "dev-weekly 2025-05-10"
 tags: ["node","javascript","frontend", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20250517.md
+++ b/src/content/weekly/dev-weekly-20250517.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-05-17
-date: "2025-05-17T17:44:00.000Z"
+date: "2025-05-17T17:44:00+09:00"
 description: "dev-weekly 2025-05-17"
 tags: ["node","css", "browser"]
 ---

--- a/src/content/weekly/dev-weekly-20250524.md
+++ b/src/content/weekly/dev-weekly-20250524.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-05-24
-date: "2025-05-24T23:41:00.000Z"
+date: "2025-05-24T23:41:00+09:00"
 description: "dev-weekly 2025-05-24"
 tags: ["node","css", "javascript", "chrome"]
 ---

--- a/src/content/weekly/dev-weekly-20250607.md
+++ b/src/content/weekly/dev-weekly-20250607.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-06-07
-date: "2025-06-07T16:55:00.000Z"
+date: "2025-06-07T16:55:00+09:00"
 description: "dev-weekly 2025-06-07"
 tags: ["node", "javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20250614.md
+++ b/src/content/weekly/dev-weekly-20250614.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-06-14
-date: "2025-06-14T23:12:00.000Z"
+date: "2025-06-14T23:12:00+09:00"
 description: "dev-weekly 2025-06-14"
 tags: ["css", "node", "javascript", "react", "browser"]
 ---

--- a/src/content/weekly/dev-weekly-20250621.md
+++ b/src/content/weekly/dev-weekly-20250621.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-06-21
-date: "2025-06-21T18:37:00.000Z"
+date: "2025-06-21T18:37:00+09:00"
 description: "dev-weekly 2025-06-21"
 tags: ["css", "node", "javascript", "react", "browser"]
 ---

--- a/src/content/weekly/dev-weekly-20250628.md
+++ b/src/content/weekly/dev-weekly-20250628.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-06-28
-date: "2025-06-28T22:02:00.000Z"
+date: "2025-06-28T22:02:00+09:00"
 description: "dev-weekly 2025-06-28"
 tags: ["css", "node", "javascript", "ai"]
 ---

--- a/src/content/weekly/dev-weekly-20250705.md
+++ b/src/content/weekly/dev-weekly-20250705.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-07-05
-date: "2025-07-05T17:35:00.000Z"
+date: "2025-07-05T17:35:00+09:00"
 description: "dev-weekly 2025-07-05"
 tags: ["css", "node", "javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20250712.md
+++ b/src/content/weekly/dev-weekly-20250712.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-07-12
-date: "2025-07-12T19:56:00.000Z"
+date: "2025-07-12T19:56:00+09:00"
 description: "dev-weekly 2025-07-12"
 tags: ["css", "node", "javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20250719.md
+++ b/src/content/weekly/dev-weekly-20250719.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-07-19
-date: "2025-07-19T19:56:00.000Z"
+date: "2025-07-19T19:56:00+09:00"
 description: "dev-weekly 2025-07-19"
 tags: ["css", "node", "javascript", "WASM"]
 ---

--- a/src/content/weekly/dev-weekly-20250726.md
+++ b/src/content/weekly/dev-weekly-20250726.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-07-26
-date: "2025-07-26T22:11:00.000Z"
+date: "2025-07-26T22:11:00+09:00"
 description: "dev-weekly 2025-07-26"
 tags: ["node", "javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20250802.md
+++ b/src/content/weekly/dev-weekly-20250802.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-08-02
-date: "2025-08-02T22:37:00.000Z"
+date: "2025-08-02T22:37:00+09:00"
 description: "dev-weekly 2025-08-02"
 tags: ["css", "node", "javascript", "w3c", "chrome", "edge"]
 ---

--- a/src/content/weekly/dev-weekly-20250809.md
+++ b/src/content/weekly/dev-weekly-20250809.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-08-09
-date: "2025-08-09T22:28:00.000Z"
+date: "2025-08-09T22:28:00+09:00"
 description: "dev-weekly 2025-08-09"
 tags: ["node", "javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20250816.md
+++ b/src/content/weekly/dev-weekly-20250816.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-08-16
-date: "2025-08-16T18:15:00.000Z"
+date: "2025-08-16T18:15:00+09:00"
 description: "dev-weekly 2025-08-16"
 tags: ["css"]
 ---

--- a/src/content/weekly/dev-weekly-20250823.md
+++ b/src/content/weekly/dev-weekly-20250823.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-08-23
-date: "2025-08-23T23:16:00.000Z"
+date: "2025-08-23T23:16:00+09:00"
 description: "dev-weekly 2025-08-23"
 tags: ["css", "nodejs", "javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20250830.md
+++ b/src/content/weekly/dev-weekly-20250830.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-08-30
-date: "2025-08-30T21:12:00.000Z"
+date: "2025-08-30T21:12:00+09:00"
 description: "dev-weekly 2025-08-30"
 tags: ["css", "javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20250906.md
+++ b/src/content/weekly/dev-weekly-20250906.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-09-06
-date: "2025-09-06T21:30:00.000Z"
+date: "2025-09-06T21:30:00+09:00"
 description: "dev-weekly 2025-09-06"
 tags: ["javascript", "browser", "chrome"]
 ---

--- a/src/content/weekly/dev-weekly-20250913.md
+++ b/src/content/weekly/dev-weekly-20250913.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-09-13
-date: "2025-09-13T20:13:00.000Z"
+date: "2025-09-13T20:13:00+09:00"
 description: "dev-weekly 2025-09-13"
 tags: ["css", "nodejs", "javascript", "bun", "deno"]
 ---

--- a/src/content/weekly/dev-weekly-20250920.md
+++ b/src/content/weekly/dev-weekly-20250920.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-09-20
-date: "2025-09-20T18:55:00.000Z"
+date: "2025-09-20T18:55:00+09:00"
 description: "dev-weekly 2025-09-20"
 tags: ["javascript", "npm", "wasm"]
 ---

--- a/src/content/weekly/dev-weekly-20250927.md
+++ b/src/content/weekly/dev-weekly-20250927.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-09-27
-date: "2025-09-27T23:16:00.000Z"
+date: "2025-09-27T23:16:00+09:00"
 description: "dev-weekly 2025-09-27"
 tags: ["javascript", "css", "browser", "ai"]
 ---

--- a/src/content/weekly/dev-weekly-20251004.md
+++ b/src/content/weekly/dev-weekly-20251004.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-10-04
-date: "2025-10-04T23:16:00.000Z"
+date: "2025-10-04T23:16:00+09:00"
 description: "dev-weekly 2025-10-04"
 tags: ["javascript", "css", "nodejs", "workers", "npx", "http"]
 ---

--- a/src/content/weekly/dev-weekly-20251011.md
+++ b/src/content/weekly/dev-weekly-20251011.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-10-11
-date: "2025-10-11T22:19:00.000Z"
+date: "2025-10-11T22:19:00+09:00"
 description: "dev-weekly 2025-10-11"
 tags: ["javascript", "css", "nodejs", "bun"]
 ---

--- a/src/content/weekly/dev-weekly-20251018.md
+++ b/src/content/weekly/dev-weekly-20251018.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-10-18
-date: "2025-10-18T22:21:00.000Z"
+date: "2025-10-18T22:21:00+09:00"
 description: "dev-weekly 2025-10-18"
 tags: ["javascript", "nodejs"]
 ---

--- a/src/content/weekly/dev-weekly-20251025.md
+++ b/src/content/weekly/dev-weekly-20251025.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-10-25
-date: "2025-10-25T18:20:00.000Z"
+date: "2025-10-25T18:20:00+09:00"
 description: "dev-weekly 2025-10-25"
 tags: ["javascript", "nodejs", "vitest", "biome"]
 ---

--- a/src/content/weekly/dev-weekly-20251101.md
+++ b/src/content/weekly/dev-weekly-20251101.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-11-01
-date: "2025-11-01T20:25:00.000Z"
+date: "2025-11-01T20:25:00+09:00"
 description: "dev-weekly 2025-11-01"
 tags: ["javascript", "nodejs", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20251108.md
+++ b/src/content/weekly/dev-weekly-20251108.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-11-08
-date: "2025-11-08T20:25:00.000Z"
+date: "2025-11-08T20:25:00+09:00"
 description: "dev-weekly 2025-11-08"
 tags: ["javascript", "bun", "css", "video", "animation"]
 ---

--- a/src/content/weekly/dev-weekly-20251115.md
+++ b/src/content/weekly/dev-weekly-20251115.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-11-15
-date: "2025-11-15T20:25:00.000Z"
+date: "2025-11-15T20:25:00+09:00"
 description: "dev-weekly 2025-11-15"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20251122.md
+++ b/src/content/weekly/dev-weekly-20251122.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-11-22
-date: "2025-11-22T19:37:00.000Z"
+date: "2025-11-22T19:37:00+09:00"
 description: "dev-weekly 2025-11-22"
 tags: ["css", "nodejs"]
 ---

--- a/src/content/weekly/dev-weekly-20251129.md
+++ b/src/content/weekly/dev-weekly-20251129.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-11-29
-date: "2025-11-29T18:15:00.000Z"
+date: "2025-11-29T18:15:00+09:00"
 description: "dev-weekly 2025-11-29"
 tags: ["css", "nodejs", "javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20251206.md
+++ b/src/content/weekly/dev-weekly-20251206.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-12-06
-date: "2025-12-06T23:08:00.000Z"
+date: "2025-12-06T23:08:00+09:00"
 description: "dev-weekly 2025-12-06"
 tags: ["css", "nodejs", "javascript", "bun"]
 ---

--- a/src/content/weekly/dev-weekly-20251213.md
+++ b/src/content/weekly/dev-weekly-20251213.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-12-13
-date: "2025-12-13T20:11:00.000Z"
+date: "2025-12-13T20:11:00+09:00"
 description: "dev-weekly 2025-12-13"
 tags: ["nodejs", "javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20251220.md
+++ b/src/content/weekly/dev-weekly-20251220.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2025-12-20
-date: "2025-12-20T17:52:00.000Z"
+date: "2025-12-20T17:52:00+09:00"
 description: "dev-weekly 2025-12-20"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20260110.md
+++ b/src/content/weekly/dev-weekly-20260110.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2026-01-10
-date: "2026-01-10T19:57:00.000Z"
+date: "2026-01-10T19:57:00+09:00"
 description: "dev-weekly 2026-01-10"
 tags: ["javascript", "nodejs", "bun"]
 ---

--- a/src/content/weekly/dev-weekly-20260117.md
+++ b/src/content/weekly/dev-weekly-20260117.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2026-01-17
-date: "2026-01-17T18:02:00.000Z"
+date: "2026-01-17T18:02:00+09:00"
 description: "dev-weekly 2026-01-17"
 tags: ["javascript", "nodejs"]
 ---

--- a/src/content/weekly/dev-weekly-20260124.md
+++ b/src/content/weekly/dev-weekly-20260124.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2026-01-24
-date: "2026-01-24T20:58:00.000Z"
+date: "2026-01-24T20:58:00+09:00"
 description: "dev-weekly 2026-01-24"
 tags: ["javascript", "nodejs"]
 ---

--- a/src/content/weekly/dev-weekly-20260131.md
+++ b/src/content/weekly/dev-weekly-20260131.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2026-01-31
-date: "2026-01-31T20:35:00.000Z"
+date: "2026-01-31T20:35:00+09:00"
 description: "dev-weekly 2026-01-31"
 tags: ["javascript", "nodejs", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20260207.md
+++ b/src/content/weekly/dev-weekly-20260207.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2026-02-07
-date: "2026-02-07T22:46:00.000Z"
+date: "2026-02-07T22:46:00+09:00"
 description: "dev-weekly 2026-02-07"
 tags: ["javascript", "nodejs", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20260214.md
+++ b/src/content/weekly/dev-weekly-20260214.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2026-02-14
-date: "2026-02-14T20:42:00.000Z"
+date: "2026-02-14T20:42:00+09:00"
 description: "dev-weekly 2026-02-14"
 tags: ["javascript", "nodejs", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20260221.md
+++ b/src/content/weekly/dev-weekly-20260221.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2026-02-21
-date: "2026-02-21T17:36:00.000Z"
+date: "2026-02-21T17:36:00+09:00"
 description: "dev-weekly 2026-02-21"
 tags: ["javascript", "nodejs", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20260228.md
+++ b/src/content/weekly/dev-weekly-20260228.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2026-02-28
-date: "2026-02-28T21:58:00.000Z"
+date: "2026-02-28T21:58:00+09:00"
 description: "dev-weekly 2026-02-28"
 tags: ["javascript", "nodejs", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20260307.md
+++ b/src/content/weekly/dev-weekly-20260307.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2026-03-07
-date: "2026-03-07T21:04:00.000Z"
+date: "2026-03-07T21:04:00+09:00"
 description: "dev-weekly 2026-03-07"
 tags: ["javascript", "nodejs"]
 ---

--- a/src/content/weekly/dev-weekly-20260314.md
+++ b/src/content/weekly/dev-weekly-20260314.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2026-03-14
-date: "2026-03-14T21:54:00.000Z"
+date: "2026-03-14T21:54:00+09:00"
 description: "dev-weekly 2026-03-14"
 tags: ["javascript", "nodejs"]
 ---

--- a/src/content/weekly/dev-weekly-20260321.md
+++ b/src/content/weekly/dev-weekly-20260321.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2026-03-21
-date: "2026-03-21T22:47:00.000Z"
+date: "2026-03-21T22:47:00+09:00"
 description: "dev-weekly 2026-03-21"
 tags: ["javascript", "nodejs", "jpeg"]
 ---

--- a/src/content/weekly/dev-weekly-20260328.md
+++ b/src/content/weekly/dev-weekly-20260328.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2026-03-28
-date: "2026-03-28T22:24:00.000Z"
+date: "2026-03-28T22:24:00+09:00"
 description: "dev-weekly 2026-03-28"
 tags: ["javascript", "nodejs", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20260404.md
+++ b/src/content/weekly/dev-weekly-20260404.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2026-04-04
-date: "2026-04-04T22:31:00.000Z"
+date: "2026-04-04T22:31:00+09:00"
 description: "dev-weekly 2026-04-04"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/dev-weekly-20260411.md
+++ b/src/content/weekly/dev-weekly-20260411.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2026-04-11
-date: "2026-04-11T21:24:00.000Z"
+date: "2026-04-11T21:24:00+09:00"
 description: "dev-weekly 2026-04-11"
 tags: ["javascript", "nodejs"]
 ---

--- a/src/content/weekly/dev-weekly-20260418.md
+++ b/src/content/weekly/dev-weekly-20260418.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2026-04-18
-date: "2026-04-18T20:20:00.000Z"
+date: "2026-04-18T20:20:00+09:00"
 description: "dev-weekly 2026-04-18"
 tags: ["javascript", "nodejs", "css", "AEO", "v8"]
 ---

--- a/src/content/weekly/dev-weekly-20260425.md
+++ b/src/content/weekly/dev-weekly-20260425.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2026-04-25
-date: "2026-04-25T23:04:00.000Z"
+date: "2026-04-25T23:04:00+09:00"
 description: "dev-weekly 2026-04-25"
 tags: ["javascript", "nodejs", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20260502.md
+++ b/src/content/weekly/dev-weekly-20260502.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2026-05-02
-date: "2026-05-02T15:25:00.000Z"
+date: "2026-05-02T15:25:00+09:00"
 description: "dev-weekly 2026-05-02"
 tags: ["javascript", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20260509.md
+++ b/src/content/weekly/dev-weekly-20260509.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2026-05-09
-date: "2026-05-09T17:54:00.000Z"
+date: "2026-05-09T17:54:00+09:00"
 description: "dev-weekly 2026-05-09"
 tags: ["javascript", "nodejs", "css"]
 ---

--- a/src/content/weekly/dev-weekly-20260516.md
+++ b/src/content/weekly/dev-weekly-20260516.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2026-05-16
-date: "2026-05-16T21:31:00.000Z"
+date: "2026-05-16T21:31:00+09:00"
 description: "dev-weekly 2026-05-16"
 tags: ["javascript", "nodejs"]
 ---

--- a/src/content/weekly/weekly-20200208.md
+++ b/src/content/weekly/weekly-20200208.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-02-08
-date: "2020-02-08T08:30:00.000Z"
+date: "2020-02-08T08:30:00+09:00"
 description: "javascript weekly 2020-02-08"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200215.md
+++ b/src/content/weekly/weekly-20200215.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-02-15
-date: "2020-02-15T08:30:00.000Z"
+date: "2020-02-15T08:30:00+09:00"
 description: "javascript weekly 2020-02-15"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200222.md
+++ b/src/content/weekly/weekly-20200222.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-02-22
-date: "2020-02-22T08:30:00.000Z"
+date: "2020-02-22T08:30:00+09:00"
 description: "javascript weekly 2020-02-22"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200229.md
+++ b/src/content/weekly/weekly-20200229.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-02-29
-date: "2020-02-29T08:30:00.000Z"
+date: "2020-02-29T08:30:00+09:00"
 description: "javascript weekly 2020-02-29"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200307.md
+++ b/src/content/weekly/weekly-20200307.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-03-07
-date: "2020-03-07T08:30:00.000Z"
+date: "2020-03-07T08:30:00+09:00"
 description: "javascript weekly 2020-03-07"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200314.md
+++ b/src/content/weekly/weekly-20200314.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-03-14
-date: "2020-03-14T08:30:00.000Z"
+date: "2020-03-14T08:30:00+09:00"
 description: "javascript weekly 2020-03-14. 재미난 글이 적어서 VSCode UPdate를 끼워넣음"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200321.md
+++ b/src/content/weekly/weekly-20200321.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-03-21
-date: "2020-03-21T08:30:00.000Z"
+date: "2020-03-21T08:30:00+09:00"
 description: "javascript weekly 2020-03-21"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200328.md
+++ b/src/content/weekly/weekly-20200328.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-03-28
-date: "2020-03-28T08:30:00.000Z"
+date: "2020-03-28T08:30:00+09:00"
 description: "javascript weekly 2020-03-28"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200404.md
+++ b/src/content/weekly/weekly-20200404.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-04-04
-date: "2020-04-04T08:30:00.000Z"
+date: "2020-04-04T08:30:00+09:00"
 description: "javascript weekly 2020-04-04"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200411.md
+++ b/src/content/weekly/weekly-20200411.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-04-11
-date: "2020-04-11T08:00:00.000Z"
+date: "2020-04-11T08:00:00+09:00"
 description: "javascript weekly 2020-04-11"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200502.md
+++ b/src/content/weekly/weekly-20200502.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-05-02
-date: "2020-05-02T09:30:00.000Z"
+date: "2020-05-02T09:30:00+09:00"
 description: "javascript weekly 2020-05-02"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200509.md
+++ b/src/content/weekly/weekly-20200509.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-05-09
-date: "2020-05-09T09:30:00.000Z"
+date: "2020-05-09T09:30:00+09:00"
 description: "javascript weekly 2020-05-09"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200516.md
+++ b/src/content/weekly/weekly-20200516.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-05-16
-date: "2020-05-16T09:00:00.000Z"
+date: "2020-05-16T09:00:00+09:00"
 description: "javascript weekly 2020-05-16"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200523.md
+++ b/src/content/weekly/weekly-20200523.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-05-23
-date: "2020-05-23T09:00:00.000Z"
+date: "2020-05-23T09:00:00+09:00"
 description: "javascript weekly 2020-05-23"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200530.md
+++ b/src/content/weekly/weekly-20200530.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-05-30
-date: "2020-05-30T09:00:00.000Z"
+date: "2020-05-30T09:00:00+09:00"
 description: "javascript weekly 2020-05-30"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200606.md
+++ b/src/content/weekly/weekly-20200606.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-06-06
-date: "2020-06-06T09:30:00.000Z"
+date: "2020-06-06T09:30:00+09:00"
 description: "javascript weekly 2020-06-06"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200613.md
+++ b/src/content/weekly/weekly-20200613.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-06-13
-date: "2020-06-13T09:30:00.000Z"
+date: "2020-06-13T09:30:00+09:00"
 description: "javascript weekly 2020-06-13"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200620.md
+++ b/src/content/weekly/weekly-20200620.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-06-20
-date: "2020-06-20T09:30:00.000Z"
+date: "2020-06-20T09:30:00+09:00"
 description: "javascript weekly 2020-06-20"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200627.md
+++ b/src/content/weekly/weekly-20200627.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-06-27
-date: "2020-06-27T09:00:00.000Z"
+date: "2020-06-27T09:00:00+09:00"
 description: "javascript weekly 2020-06-27"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200704.md
+++ b/src/content/weekly/weekly-20200704.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-07-04
-date: "2020-07-04T08:30:00.000Z"
+date: "2020-07-04T08:30:00+09:00"
 description: "javascript weekly 2020-07-04"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200711.md
+++ b/src/content/weekly/weekly-20200711.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-07-11
-date: "2020-07-11T09:00:00.000Z"
+date: "2020-07-11T09:00:00+09:00"
 description: "javascript weekly 2020-07-11"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200718.md
+++ b/src/content/weekly/weekly-20200718.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-07-18
-date: "2020-07-18T09:30:00.000Z"
+date: "2020-07-18T09:30:00+09:00"
 description: "javascript weekly 2020-07-18"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200725.md
+++ b/src/content/weekly/weekly-20200725.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-07-25
-date: "2020-07-25T10:30:00.000Z"
+date: "2020-07-25T10:30:00+09:00"
 description: "javascript weekly 2020-07-25"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200801.md
+++ b/src/content/weekly/weekly-20200801.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-08-01
-date: "2020-08-01T09:30:00.000Z"
+date: "2020-08-01T09:30:00+09:00"
 description: "javascript weekly 2020-08-01"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200808.md
+++ b/src/content/weekly/weekly-20200808.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-08-08
-date: "2020-08-08T09:30:00.000Z"
+date: "2020-08-08T09:30:00+09:00"
 description: "javascript weekly 2020-08-08"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200815.md
+++ b/src/content/weekly/weekly-20200815.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-08-15
-date: "2020-08-15T08:30:00.000Z"
+date: "2020-08-15T08:30:00+09:00"
 description: "javascript weekly 2020-08-15"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200822.md
+++ b/src/content/weekly/weekly-20200822.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-08-22
-date: "2020-08-22T08:30:00.000Z"
+date: "2020-08-22T08:30:00+09:00"
 description: "javascript weekly 2020-08-22"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200829.md
+++ b/src/content/weekly/weekly-20200829.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-08-29
-date: "2020-08-29T09:30:00.000Z"
+date: "2020-08-29T09:30:00+09:00"
 description: "javascript weekly 2020-08-29"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200905.md
+++ b/src/content/weekly/weekly-20200905.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-09-05
-date: "2020-09-05T09:30:00.000Z"
+date: "2020-09-05T09:30:00+09:00"
 description: "javascript weekly 2020-09-05"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200912.md
+++ b/src/content/weekly/weekly-20200912.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-09-12
-date: "2020-09-12T09:30:00.000Z"
+date: "2020-09-12T09:30:00+09:00"
 description: "javascript weekly 2020-09-12"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200919.md
+++ b/src/content/weekly/weekly-20200919.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-09-19
-date: "2020-09-19T09:00:00.000Z"
+date: "2020-09-19T09:00:00+09:00"
 description: "javascript weekly 2020-09-19"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20200926.md
+++ b/src/content/weekly/weekly-20200926.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-09-26
-date: "2020-09-26T08:30:00.000Z"
+date: "2020-09-26T08:30:00+09:00"
 description: "javascript weekly 2020-09-26"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20201003.md
+++ b/src/content/weekly/weekly-20201003.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-10-03
-date: "2020-10-03T09:30:00.000Z"
+date: "2020-10-03T09:30:00+09:00"
 description: "javascript weekly 2020-10-03"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20201010.md
+++ b/src/content/weekly/weekly-20201010.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-10-10
-date: "2020-10-10T08:00:00.000Z"
+date: "2020-10-10T08:00:00+09:00"
 description: "javascript weekly 2020-10-10"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20201017.md
+++ b/src/content/weekly/weekly-20201017.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-10-17
-date: "2020-10-17T09:30:00.000Z"
+date: "2020-10-17T09:30:00+09:00"
 description: "javascript weekly 2020-10-17"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20201024.md
+++ b/src/content/weekly/weekly-20201024.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-10-24
-date: "2020-10-24T10:00:00.000Z"
+date: "2020-10-24T10:00:00+09:00"
 description: "javascript weekly 2020-10-24"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20201031.md
+++ b/src/content/weekly/weekly-20201031.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-10-31
-date: "2020-10-31T10:00:00.000Z"
+date: "2020-10-31T10:00:00+09:00"
 description: "javascript weekly 2020-10-31"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20201107.md
+++ b/src/content/weekly/weekly-20201107.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-11-07
-date: "2020-11-07T09:00:00.000Z"
+date: "2020-11-07T09:00:00+09:00"
 description: "javascript weekly 2020-11-07"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20201114.md
+++ b/src/content/weekly/weekly-20201114.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-11-14
-date: "2020-11-14T09:10:00.000Z"
+date: "2020-11-14T09:10:00+09:00"
 description: "javascript weekly 2020-11-14"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20201121.md
+++ b/src/content/weekly/weekly-20201121.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-11-21
-date: "2020-11-21T09:30:00.000Z"
+date: "2020-11-21T09:30:00+09:00"
 description: "javascript weekly 2020-11-21"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20201128.md
+++ b/src/content/weekly/weekly-20201128.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-11-28
-date: "2020-11-28T10:00:00.000Z"
+date: "2020-11-28T10:00:00+09:00"
 description: "javascript weekly 2020-11-28"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20201205.md
+++ b/src/content/weekly/weekly-20201205.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-12-05
-date: "2020-12-05T10:00:00.000Z"
+date: "2020-12-05T10:00:00+09:00"
 description: "javascript weekly 2020-12-05"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20201212.md
+++ b/src/content/weekly/weekly-20201212.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-12-12
-date: "2020-12-12T09:00:00.000Z"
+date: "2020-12-12T09:00:00+09:00"
 description: "javascript weekly 2020-12-12"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20201219.md
+++ b/src/content/weekly/weekly-20201219.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2020-12-19
-date: "2020-12-19T10:00:00.000Z"
+date: "2020-12-19T10:00:00+09:00"
 description: "javascript weekly 2020-12-19"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20210109.md
+++ b/src/content/weekly/weekly-20210109.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2021-01-09
-date: "2021-01-09T09:30:00.000Z"
+date: "2021-01-09T09:30:00+09:00"
 description: "javascript weekly 2021-01-09, 2020 rank"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20210116.md
+++ b/src/content/weekly/weekly-20210116.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2021-01-16
-date: "2021-01-16T08:40:00.000Z"
+date: "2021-01-16T08:40:00+09:00"
 description: "javascript weekly 2021-01-16"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20210123.md
+++ b/src/content/weekly/weekly-20210123.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2021-01-23
-date: "2021-01-23T09:30:00.000Z"
+date: "2021-01-23T09:30:00+09:00"
 description: "javascript weekly 2021-01-23"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20210130.md
+++ b/src/content/weekly/weekly-20210130.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2021-01-30
-date: "2021-01-30T09:40:00.000Z"
+date: "2021-01-30T09:40:00+09:00"
 description: "javascript weekly 2021-01-30"
 tags: ["javascript"]
 ---

--- a/src/content/weekly/weekly-20210206.md
+++ b/src/content/weekly/weekly-20210206.md
@@ -1,6 +1,6 @@
 ---
 title: javascript weekly 2021-02-06
-date: "2021-02-06T09:40:00.000Z"
+date: "2021-02-06T09:40:00+09:00"
 description: "javascript weekly 2021-02-06"
 tags: ["javascript"]
 ---


### PR DESCRIPTION
기존에는 `date: "...Z"` (UTC) 표기였으나, 실제로는 KST 의도로 작성된 값이라 표시 시 늦은 시간대 글이 하루 밀려 보이는 문제가 있었음. 모든 콘텐츠의
date 값을 `+09:00`로 명시 변환.

- scripts/normalize-dates.mjs: 일괄 변환용 스크립트 (멱등)
- src/content/{weekly,blog,archive}/*.md: 323개 파일의 date 표기 보정