### PR TITLE
style: 헤더 nav에서 Home 제거

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -14,7 +14,6 @@ import { SITE_TITLE } from '../consts';
   <nav>
     <a class="brand" href="/">{SITE_TITLE}</a>
     <div class="internal-links">
-      <HeaderLink href="/">Home</HeaderLink>
       <HeaderLink href="/blog">Blog</HeaderLink>
       <HeaderLink href="/weekly">Weekly</HeaderLink>
       <HeaderLink href="/archive">Archive</HeaderLink>


### PR DESCRIPTION
브랜드 로고 클릭이 `/`로 이동하므로 Home 메뉴가 중복.
Blog/Weekly/Archive만 남김.