### PR TITLE
ci: PR 작성자를 자동으로 assignee로 지정

### DIFF
--- a/.github/workflows/auto-assign-pr-author.yml
+++ b/.github/workflows/auto-assign-pr-author.yml
@@ -1,0 +1,23 @@
+name: Auto Assign PR Author
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign PR to its author
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              assignees: [context.payload.pull_request.user.login],
+            });


### PR DESCRIPTION
PR이 열리거나 다시 열릴 때 작성자를 assignee로 추가하는
GitHub Actions 워크플로 추가