### PR TITLE
feat: blog·weekly 검색 기능 추가 (Pagefind)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,11 +3,12 @@ import mdx from '@astrojs/mdx';
 import rehypeExternalLinks from 'rehype-external-links';
 
 import sitemap from '@astrojs/sitemap';
+import pagefind from 'astro-pagefind';
 
 // https://astro.build/config
 export default defineConfig({
   site: 'https://stupidk.com',
-  integrations: [mdx(), sitemap()],
+  integrations: [mdx(), sitemap(), pagefind()],
   redirects: {},
   markdown: {
     unified: (u) =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@astrojs/rss": "^4.0.18",
         "@astrojs/sitemap": "^3.7.3",
         "astro": "^6.4.2",
+        "astro-pagefind": "^2.0.0",
         "rehype-external-links": "^3.0.0"
       }
     },
@@ -1233,6 +1234,113 @@
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
     },
+    "node_modules/@pagefind/component-ui": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/component-ui/-/component-ui-1.5.2.tgz",
+      "integrity": "sha512-t8/aE0tan4JiKa6cyhhSt/5qrEVwAK/qlYBHFpnRoq+qaFFVrhmXFFMY+r6n4GJtVIFCN2A5nUpeLN68cYjEjw==",
+      "license": "MIT",
+      "dependencies": {
+        "adequate-little-templates": "^1.0.2",
+        "bcp-47": "^2.1.0"
+      }
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "license": "MIT"
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
@@ -1836,6 +1944,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adequate-little-templates": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/adequate-little-templates/-/adequate-little-templates-1.0.2.tgz",
+      "integrity": "sha512-d0tFFG538l3Y4CElRKtticzrMr/OGohs32/nf3Ewn8rbTMBYwkVNe8mPdXWrDnMlz+ZVUFQjsTmsBD5zCtU4wg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -1979,6 +2096,20 @@
         "sharp": "^0.34.0"
       }
     },
+    "node_modules/astro-pagefind": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astro-pagefind/-/astro-pagefind-2.0.0.tgz",
+      "integrity": "sha512-i270YlJ/8aX/eRkvtuAPANSk+WK1uyp9DEj/TuuWem4pA0xBUGQk7agNFdu71nRxtH0j7TZxee2qwQRlrfZa1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@pagefind/component-ui": "^1.5.0",
+        "pagefind": "^1.5.0",
+        "sirv": "^3.0.0"
+      },
+      "peerDependencies": {
+        "astro": "^2.0.4 || ^3 || ^4 || ^5 || ^6"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -1993,6 +2124,21 @@
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
       "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
       "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/bcp-47": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bcp-47/-/bcp-47-2.1.0.tgz",
+      "integrity": "sha512-9IIS3UPrvIa1Ej+lVDdDwO7zLehjqsaByECw0bu2RRGP73jALm6FYbzI5gWbgHLvNdkvfXB5YrSbocZdOS0c0w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -4449,6 +4595,24 @@
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
     },
+    "node_modules/pagefind": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.5.2",
+        "@pagefind/darwin-x64": "1.5.2",
+        "@pagefind/freebsd-x64": "1.5.2",
+        "@pagefind/linux-arm64": "1.5.2",
+        "@pagefind/linux-x64": "1.5.2",
+        "@pagefind/windows-arm64": "1.5.2",
+        "@pagefind/windows-x64": "1.5.2"
+      }
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -5094,6 +5258,20 @@
         "node": ">=20"
       }
     },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -5270,6 +5448,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/trim-lines": {
@@ -6356,6 +6543,62 @@
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="
     },
+    "@pagefind/component-ui": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/component-ui/-/component-ui-1.5.2.tgz",
+      "integrity": "sha512-t8/aE0tan4JiKa6cyhhSt/5qrEVwAK/qlYBHFpnRoq+qaFFVrhmXFFMY+r6n4GJtVIFCN2A5nUpeLN68cYjEjw==",
+      "requires": {
+        "adequate-little-templates": "^1.0.2",
+        "bcp-47": "^2.1.0"
+      }
+    },
+    "@pagefind/darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "optional": true
+    },
+    "@pagefind/darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "optional": true
+    },
+    "@pagefind/freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "optional": true
+    },
+    "@pagefind/linux-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "optional": true
+    },
+    "@pagefind/linux-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "optional": true
+    },
+    "@pagefind/windows-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "optional": true
+    },
+    "@pagefind/windows-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "optional": true
+    },
+    "@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="
+    },
     "@rollup/pluginutils": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
@@ -6686,6 +6929,11 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "requires": {}
     },
+    "adequate-little-templates": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/adequate-little-templates/-/adequate-little-templates-1.0.2.tgz",
+      "integrity": "sha512-d0tFFG538l3Y4CElRKtticzrMr/OGohs32/nf3Ewn8rbTMBYwkVNe8mPdXWrDnMlz+ZVUFQjsTmsBD5zCtU4wg=="
+    },
     "anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -6790,6 +7038,16 @@
         "zod": "^4.3.6"
       }
     },
+    "astro-pagefind": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astro-pagefind/-/astro-pagefind-2.0.0.tgz",
+      "integrity": "sha512-i270YlJ/8aX/eRkvtuAPANSk+WK1uyp9DEj/TuuWem4pA0xBUGQk7agNFdu71nRxtH0j7TZxee2qwQRlrfZa1g==",
+      "requires": {
+        "@pagefind/component-ui": "^1.5.0",
+        "pagefind": "^1.5.0",
+        "sirv": "^3.0.0"
+      }
+    },
     "axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -6799,6 +7057,16 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
       "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+    },
+    "bcp-47": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bcp-47/-/bcp-47-2.1.0.tgz",
+      "integrity": "sha512-9IIS3UPrvIa1Ej+lVDdDwO7zLehjqsaByECw0bu2RRGP73jALm6FYbzI5gWbgHLvNdkvfXB5YrSbocZdOS0c0w==",
+      "requires": {
+        "is-alphabetical": "^2.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      }
     },
     "boolbase": {
       "version": "1.0.0",
@@ -8323,6 +8591,20 @@
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="
     },
+    "pagefind": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "requires": {
+        "@pagefind/darwin-arm64": "1.5.2",
+        "@pagefind/darwin-x64": "1.5.2",
+        "@pagefind/freebsd-x64": "1.5.2",
+        "@pagefind/linux-arm64": "1.5.2",
+        "@pagefind/linux-x64": "1.5.2",
+        "@pagefind/windows-arm64": "1.5.2",
+        "@pagefind/windows-x64": "1.5.2"
+      }
+    },
     "parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -8757,6 +9039,16 @@
         "@types/hast": "^3.0.4"
       }
     },
+    "sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "requires": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      }
+    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -8865,6 +9157,11 @@
         "fdir": "^6.5.0",
         "picomatch": "^4.0.4"
       }
+    },
+    "totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="
     },
     "trim-lines": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.3",
     "astro": "^6.4.2",
+    "astro-pagefind": "^2.0.0",
     "rehype-external-links": "^3.0.0"
   }
 }

--- a/src/components/FormattedDate.astro
+++ b/src/components/FormattedDate.astro
@@ -1,13 +1,18 @@
 ---
 interface Props {
   date: Date;
+  /** true 면 Pagefind 가 정렬용으로 읽을 수 있도록 date 메타(datetime 값)를 노출 */
+  pagefindMeta?: boolean;
 }
 
-const { date } = Astro.props;
+const { date, pagefindMeta = false } = Astro.props;
 const parsedDate = new Date(date);
 ---
 
-<time datetime={parsedDate.toISOString()}>
+<time
+  datetime={parsedDate.toISOString()}
+  data-pagefind-meta={pagefindMeta ? 'date[datetime]' : undefined}
+>
   {
     parsedDate.toLocaleDateString('ko-KR', {
       year: 'numeric',

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,5 +1,6 @@
 ---
 import HeaderLink from './HeaderLink.astro';
+import Search from './Search.astro';
 import { SITE_TITLE } from '../consts';
 ---
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-Z0RKTW6K2K"></script>
@@ -17,6 +18,9 @@ import { SITE_TITLE } from '../consts';
       <HeaderLink href="/blog">Blog</HeaderLink>
       <HeaderLink href="/weekly">Weekly</HeaderLink>
       <HeaderLink href="/archive">Archive</HeaderLink>
+    </div>
+    <div class="search">
+      <Search />
     </div>
     <div class="social-links">
       <a href="https://github.com/deadintegral/stupidk-blog-astro" target="_blank" aria-label="GitHub">
@@ -97,6 +101,10 @@ import { SITE_TITLE } from '../consts';
     background: color-mix(in srgb, var(--accent) 10%, transparent);
     text-decoration: none;
     font-weight: 600;
+  }
+  .search {
+    display: flex;
+    align-items: center;
   }
   .social-links {
     display: flex;

--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -1,0 +1,356 @@
+---
+// 검색: 네이티브 <dialog> + Pagefind JS API 직접 렌더링 (blog + weekly 인덱스).
+// 헤더 아이콘 또는 ⌘K / Ctrl+K 로 열린다.
+// 결과 정렬: 정확도(score) 우선, 동점이면 최신 날짜순.
+---
+
+<button
+  id="pf-search-trigger"
+  class="pf-search-trigger"
+  type="button"
+  aria-label="검색"
+  aria-haspopup="dialog"
+>
+  <svg
+    class="pf-search-icon"
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <circle cx="11" cy="11" r="7"></circle>
+    <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+  </svg>
+  <kbd class="pf-search-kbd">⌘K</kbd>
+</button>
+
+<dialog id="pf-search-dialog" class="pf-search-dialog" aria-label="검색">
+  <form class="pf-form" role="search" onsubmit="return false">
+    <svg
+      class="pf-form-icon"
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="11" cy="11" r="7"></circle>
+      <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+    </svg>
+    <input
+      id="pf-input"
+      class="pf-input"
+      type="search"
+      autocomplete="off"
+      placeholder="blog · weekly 검색…"
+      aria-label="검색어"
+    />
+  </form>
+  <div id="pf-results" class="pf-results" aria-live="polite"></div>
+</dialog>
+
+<script>
+  const trigger = document.getElementById('pf-search-trigger');
+  const dialog = document.getElementById('pf-search-dialog') as HTMLDialogElement | null;
+  const input = document.getElementById('pf-input') as HTMLInputElement | null;
+  const resultsEl = document.getElementById('pf-results');
+
+  let pf: any = null;
+  let pfLoading: Promise<any> | null = null;
+
+  function ensurePagefind() {
+    if (pf) return Promise.resolve(pf);
+    if (!pfLoading) {
+      pfLoading = (async () => {
+        // 경로를 런타임 변수로 만들어 번들러가 정적 분석/해결하지 못하게 한다.
+        const url = `${location.origin}/pagefind/pagefind.js`;
+        const mod = await import(/* @vite-ignore */ url);
+        await mod.options({ bundlePath: '/pagefind/' });
+        await mod.init();
+        pf = mod;
+        return mod;
+      })().catch((e) => {
+        pfLoading = null;
+        console.error(
+          '[search] Pagefind 인덱스를 불러오지 못했어요. `astro build` 로 인덱스를 먼저 생성하세요.',
+          e
+        );
+        throw e;
+      });
+    }
+    return pfLoading;
+  }
+
+  function esc(s: string) {
+    return s.replace(/[&<>"]/g, (c) =>
+      c === '&' ? '&amp;' : c === '<' ? '&lt;' : c === '>' ? '&gt;' : '&quot;'
+    );
+  }
+
+  function dateValue(meta: Record<string, string> | undefined) {
+    const raw = meta && meta.date;
+    const t = raw ? Date.parse(raw) : NaN;
+    return Number.isNaN(t) ? 0 : t;
+  }
+
+  function fmtDate(raw: string) {
+    const t = Date.parse(raw);
+    if (Number.isNaN(t)) return '';
+    return new Date(t).toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  }
+
+  function setMessage(html: string) {
+    if (resultsEl) resultsEl.innerHTML = `<p class="pf-message">${html}</p>`;
+  }
+
+  let activeTerm = '';
+
+  async function runSearch(term: string) {
+    if (!resultsEl) return;
+    if (!term) {
+      resultsEl.innerHTML = '';
+      return;
+    }
+    let lib;
+    try {
+      lib = await ensurePagefind();
+    } catch {
+      setMessage('검색 인덱스를 불러오지 못했어요.');
+      return;
+    }
+    if (term !== activeTerm) return; // 입력이 더 최신이면 중단
+
+    const search = await lib.search(term);
+    if (term !== activeTerm) return;
+
+    // 상위 결과의 메타까지 받아온 뒤 정확도 → 최신 날짜 순으로 보정
+    const top = search.results.slice(0, 30);
+    const items = await Promise.all(
+      top.map(async (r: any) => ({ score: r.score, data: await r.data() }))
+    );
+    if (term !== activeTerm) return;
+
+    items.sort((a, b) => b.score - a.score || dateValue(b.data.meta) - dateValue(a.data.meta));
+
+    if (!items.length) {
+      setMessage(`"${esc(term)}" 검색 결과가 없어요`);
+      return;
+    }
+
+    resultsEl.innerHTML = items
+      .map(({ data }) => {
+        const title = esc(data.meta?.title || data.url);
+        const date = data.meta?.date ? fmtDate(data.meta.date) : '';
+        return `
+          <a class="pf-result" href="${data.url}">
+            <span class="pf-result-title">${title}</span>
+            <span class="pf-result-excerpt">${data.excerpt}</span>
+            ${date ? `<span class="pf-result-date">${date}</span>` : ''}
+          </a>`;
+      })
+      .join('');
+    resultsEl.scrollTop = 0;
+  }
+
+  let debounce: ReturnType<typeof setTimeout>;
+  input?.addEventListener('input', () => {
+    activeTerm = input.value.trim();
+    clearTimeout(debounce);
+    debounce = setTimeout(() => runSearch(activeTerm), 160);
+  });
+
+  function openDialog() {
+    if (!dialog) return;
+    ensurePagefind().catch(() => {});
+    if (!dialog.open) dialog.showModal();
+    requestAnimationFrame(() => input?.focus());
+  }
+
+  function closeDialog() {
+    if (dialog?.open) dialog.close();
+  }
+
+  trigger?.addEventListener('click', openDialog);
+
+  // 배경(backdrop) 클릭 시 닫기
+  dialog?.addEventListener('click', (e) => {
+    if (e.target === dialog) closeDialog();
+  });
+
+  // ⌘K / Ctrl+K 로 열고 닫기
+  document.addEventListener('keydown', (e) => {
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+      e.preventDefault();
+      dialog?.open ? closeDialog() : openDialog();
+    }
+  });
+</script>
+
+<style is:global>
+  /* 헤더 트리거 버튼 */
+  .pf-search-trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    height: 36px;
+    padding: 0 0.6rem;
+    color: var(--text-muted);
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+  }
+  .pf-search-trigger:hover {
+    color: var(--text);
+    background: var(--bg-soft);
+    border-color: var(--border-strong);
+  }
+  .pf-search-icon {
+    flex: none;
+  }
+  .pf-search-kbd {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    line-height: 1;
+    padding: 0.2rem 0.35rem;
+    color: var(--text-faint);
+    background: var(--bg-soft);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+  }
+
+  /* 모달: 입력은 고정, 결과만 스크롤 */
+  .pf-search-dialog {
+    width: min(640px, 92vw);
+    max-height: 78vh;
+    margin: 10vh auto auto;
+    padding: 0;
+    color: var(--text);
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-md);
+    overflow: hidden;
+  }
+  .pf-search-dialog[open] {
+    display: flex;
+    flex-direction: column;
+  }
+  .pf-search-dialog::backdrop {
+    background: color-mix(in srgb, #000 55%, transparent);
+    backdrop-filter: blur(2px);
+  }
+
+  .pf-form {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    flex: none;
+    padding: 0.85rem 1rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .pf-form-icon {
+    flex: none;
+    color: var(--text-faint);
+  }
+  .pf-input {
+    flex: 1;
+    min-width: 0;
+    border: none;
+    outline: none;
+    background: transparent;
+    color: var(--text);
+    font-family: var(--font-sans);
+    font-size: 1rem;
+  }
+  .pf-input::placeholder {
+    color: var(--text-faint);
+  }
+  /* 검색 input 의 기본 X 버튼은 두되 색만 정리 */
+  .pf-input::-webkit-search-cancel-button {
+    cursor: pointer;
+  }
+
+  .pf-results {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    padding: 0.5rem;
+  }
+  .pf-message {
+    margin: 0;
+    padding: 1.5rem 1rem;
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+  }
+
+  .pf-result {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.7rem 0.75rem;
+    border-radius: var(--radius-md);
+    text-decoration: none;
+    color: var(--text);
+  }
+  .pf-result:hover,
+  .pf-result:focus-visible {
+    background: var(--bg-soft);
+    text-decoration: none;
+    outline: none;
+  }
+  .pf-result-title {
+    font-weight: 600;
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+  .pf-result-excerpt {
+    font-size: 0.85rem;
+    line-height: 1.5;
+    color: var(--text-muted);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  .pf-result-excerpt mark {
+    background: color-mix(in srgb, var(--accent) 28%, transparent);
+    color: inherit;
+    border-radius: 3px;
+    padding: 0 0.1em;
+  }
+  .pf-result-date {
+    font-size: 0.75rem;
+    color: var(--text-faint);
+  }
+
+  @media (max-width: 720px) {
+    .pf-search-kbd {
+      display: none;
+    }
+    .pf-search-trigger {
+      padding: 0 0.5rem;
+    }
+    .pf-search-dialog {
+      width: 94vw;
+      max-height: 82vh;
+      margin: 6vh auto auto;
+    }
+  }
+</style>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -23,10 +23,10 @@ const { title, description, date, updatedDate, heroImage } = Astro.props;
         <div class="hero-image">
           {heroImage && <img width={1020} height={510} src={heroImage} alt="" />}
         </div>
-        <div class="prose">
+        <div class="prose" data-pagefind-body>
           <div class="title">
             <div class="date">
-              <FormattedDate date={date} />
+              <FormattedDate date={date} pagefindMeta />
               {
                 updatedDate && (
                   <div class="last-updated-on">

--- a/src/layouts/WeeklyPost.astro
+++ b/src/layouts/WeeklyPost.astro
@@ -37,11 +37,11 @@ const { title, description, date, updatedDate, heroImage } = Astro.props;
         <div class="hero-image">
           {heroImage && <img width={1020} height={510} src={heroImage} alt="" />}
         </div>
-        <div class="weekly-prose">
+        <div class="weekly-prose" data-pagefind-body>
           <div class="title">
             <h1>{title}</h1>
             <div class="date">
-              <FormattedDate date={date} />
+              <FormattedDate date={date} pagefindMeta />
               {
                 updatedDate && (
                   <div class="last-updated-on">


### PR DESCRIPTION
- 헤더 검색 아이콘 / ⌘K·Ctrl+K 로 여는 네이티브 <dialog> 모달
- Pagefind JS API 직접 렌더링: 입력은 고정, 결과 영역만 스크롤
- 정렬 보정: 정확도(score) 우선, 동점이면 최신 날짜순 (FormattedDate 에 date 메타 노출, blog/weekly 본문만 인덱싱)
- astro-pagefind 통합으로 빌드 시 인덱스 자동 생성