### PR TITLE
feat: 태그 브라우징 추가

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -18,6 +18,7 @@ import { SITE_TITLE } from '../consts';
       <HeaderLink href="/blog">Blog</HeaderLink>
       <HeaderLink href="/weekly">Weekly</HeaderLink>
       <HeaderLink href="/archive">Archive</HeaderLink>
+      <HeaderLink href="/tags">Tags</HeaderLink>
     </div>
     <div class="search">
       <Search />

--- a/src/layouts/ArchivePost.astro
+++ b/src/layouts/ArchivePost.astro
@@ -8,7 +8,7 @@ import '../styles/postDetail.css';
 
 type Props = CollectionEntry<'archive'>['data'];
 
-const { title, description, date, updatedDate, heroImage } = Astro.props;
+const { title, description, date, updatedDate, heroImage, tags } = Astro.props;
 ---
 
 <html lang="ko">
@@ -36,6 +36,17 @@ const { title, description, date, updatedDate, heroImage } = Astro.props;
               }
             </div>
             <h1>{title}</h1>
+            {
+              tags && tags.length > 0 && (
+                <p class="post-tags">
+                  {tags.map((t) => (
+                    <a class="post-tag" href={`/tags/${encodeURIComponent(t)}/`}>
+                      #{t}
+                    </a>
+                  ))}
+                </p>
+              )
+            }
             <hr />
           </div>
           <slot />

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -8,7 +8,7 @@ import '../styles/postDetail.css';
 
 type Props = CollectionEntry<'blog'>['data'];
 
-const { title, description, date, updatedDate, heroImage } = Astro.props;
+const { title, description, date, updatedDate, heroImage, tags } = Astro.props;
 ---
 
 <html lang="ko">
@@ -36,6 +36,17 @@ const { title, description, date, updatedDate, heroImage } = Astro.props;
               }
             </div>
             <h1>{title}</h1>
+            {
+              tags && tags.length > 0 && (
+                <p class="post-tags">
+                  {tags.map((t) => (
+                    <a class="post-tag" href={`/tags/${encodeURIComponent(t)}/`}>
+                      #{t}
+                    </a>
+                  ))}
+                </p>
+              )
+            }
             <hr />
           </div>
           <slot />

--- a/src/layouts/WeeklyPost.astro
+++ b/src/layouts/WeeklyPost.astro
@@ -8,7 +8,7 @@ import '../styles/postDetail.css';
 
 type Props = CollectionEntry<'weekly'>['data'];
 
-const { title, description, date, updatedDate, heroImage } = Astro.props;
+const { title, description, date, updatedDate, heroImage, tags } = Astro.props;
 ---
 
 <html lang="ko">
@@ -50,6 +50,17 @@ const { title, description, date, updatedDate, heroImage } = Astro.props;
                 )
               }
             </div>
+            {
+              tags && tags.length > 0 && (
+                <p class="post-tags">
+                  {tags.map((t) => (
+                    <a class="post-tag" href={`/tags/${encodeURIComponent(t)}/`}>
+                      #{t}
+                    </a>
+                  ))}
+                </p>
+              )
+            }
             <hr />
           </div>
           <slot />

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,0 +1,99 @@
+---
+import BaseHead from '../../components/BaseHead.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import FormattedDate from '../../components/FormattedDate.astro';
+import { SITE_TITLE } from '../../consts';
+import { getTaggedPosts, buildTagMap, postHref, type TaggedPost } from '../../utils/tags';
+import '../../styles/postList.css';
+
+export async function getStaticPaths() {
+  const posts = await getTaggedPosts();
+  const tagMap = buildTagMap(posts);
+  return [...tagMap.entries()].map(([tag, taggedPosts]) => ({
+    params: { tag },
+    props: { tag, posts: taggedPosts },
+  }));
+}
+
+interface Props {
+  tag: string;
+  posts: TaggedPost[];
+}
+
+const { tag, posts } = Astro.props;
+---
+
+<!doctype html>
+<html lang="ko">
+  <head>
+    <BaseHead title={`#${tag} · ${SITE_TITLE}`} description={`${tag} 태그가 달린 글`} />
+  </head>
+  <body>
+    <Header />
+    <main>
+      <section>
+        <p class="tag-breadcrumb"><a href="/tags">← 모든 태그</a></p>
+        <h1 class="tag-title">#{tag} <span class="tag-count">{posts.length}</span></h1>
+        <ul>
+          {
+            posts.map((post) => (
+              <li>
+                <a href={postHref(post)}>
+                  <h4 class="title">{post.title}</h4>
+                  <p class="date">
+                    <span class={`badge badge-${post.collection}`}>{post.collection}</span>
+                    <FormattedDate date={post.date} />
+                  </p>
+                </a>
+              </li>
+            ))
+          }
+        </ul>
+      </section>
+    </main>
+    <Footer />
+  </body>
+</html>
+
+<style>
+  .tag-breadcrumb {
+    margin: 0 0 0.5rem;
+    font-size: 0.875rem;
+  }
+  .tag-breadcrumb a {
+    color: var(--text-muted);
+    text-decoration: none;
+  }
+  .tag-breadcrumb a:hover {
+    color: var(--text);
+  }
+  .tag-title {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    font-size: 1.5rem;
+    margin: 0 0 1.5rem;
+  }
+  .tag-count {
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: var(--text-faint);
+  }
+  .badge {
+    display: inline-block;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    padding: 0.1rem 0.45rem;
+    border-radius: 4px;
+    margin-right: 0.5rem;
+    color: var(--text-muted);
+    background: var(--bg-soft);
+    border: 1px solid var(--border);
+  }
+  .badge-weekly {
+    color: var(--accent);
+  }
+</style>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,0 +1,96 @@
+---
+import BaseHead from '../../components/BaseHead.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import { SITE_TITLE } from '../../consts';
+import { getTaggedPosts, buildTagMap, sortedTagCounts, tagHref } from '../../utils/tags';
+
+const posts = await getTaggedPosts();
+const tagMap = buildTagMap(posts);
+const tags = sortedTagCounts(tagMap);
+---
+
+<!doctype html>
+<html lang="ko">
+  <head>
+    <BaseHead title={`Tags · ${SITE_TITLE}`} description="태그별로 글 둘러보기" />
+  </head>
+  <body>
+    <Header />
+    <main>
+      <section class="tags-page">
+        <h1 class="tags-heading">Tags <span class="tags-total">{tags.length}</span></h1>
+        <ul class="tag-cloud">
+          {
+            tags.map(({ tag, count }) => (
+              <li>
+                <a class="tag-chip" href={tagHref(tag)}>
+                  <span class="name">#{tag}</span>
+                  <span class="count">{count}</span>
+                </a>
+              </li>
+            ))
+          }
+        </ul>
+      </section>
+    </main>
+    <Footer />
+  </body>
+</html>
+
+<style>
+  .tags-page {
+    width: var(--content-width-wide);
+    max-width: 100%;
+    margin: 0 auto;
+  }
+  .tags-heading {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    font-size: 1.5rem;
+    margin: 0 0 1.5rem;
+  }
+  .tags-total {
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: var(--text-faint);
+  }
+  .tag-cloud {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  .tag-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.4rem 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--bg-elevated);
+    color: var(--text);
+    text-decoration: none;
+    font-size: 0.9rem;
+    transition: border-color 0.15s ease, transform 0.15s ease, color 0.15s ease;
+  }
+  .tag-chip:hover {
+    border-color: var(--border-strong);
+    color: var(--accent);
+    transform: translateY(-1px);
+    text-decoration: none;
+  }
+  .tag-chip .name {
+    font-weight: 500;
+  }
+  .tag-chip .count {
+    font-size: 0.75rem;
+    color: var(--text-faint);
+    background: var(--bg-soft);
+    border-radius: 999px;
+    padding: 0.05rem 0.45rem;
+  }
+</style>

--- a/src/styles/postDetail.css
+++ b/src/styles/postDetail.css
@@ -59,6 +59,29 @@ main {
   display: none;
 }
 
+.post-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0.9rem 0 0;
+}
+.post-tag {
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  text-decoration: none;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+.post-tag:hover {
+  border-color: var(--border-strong);
+  color: var(--accent);
+  text-decoration: none;
+}
+
 @media (max-width: 720px) {
   .hero-image {
     padding: 1rem 1rem 0;

--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -1,0 +1,63 @@
+import { getCollection } from 'astro:content';
+
+export type TagCollection = 'blog' | 'weekly' | 'archive';
+
+export interface TaggedPost {
+  collection: TagCollection;
+  id: string;
+  title: string;
+  date: Date;
+  tags: string[];
+}
+
+const COLLECTIONS: TagCollection[] = ['blog', 'weekly', 'archive'];
+
+/** 모든 컬렉션에서 태그가 있는 글을 모아 평탄화한다. */
+export async function getTaggedPosts(): Promise<TaggedPost[]> {
+  const groups = await Promise.all(
+    COLLECTIONS.map(async (collection) => {
+      const entries = await getCollection(collection as any);
+      return entries
+        .filter((e: any) => Array.isArray(e.data.tags) && e.data.tags.length > 0)
+        .map((e: any) => ({
+          collection,
+          id: e.id,
+          title: e.data.title,
+          date: new Date(e.data.date),
+          tags: e.data.tags as string[],
+        }));
+    })
+  );
+  return groups.flat();
+}
+
+/** 태그 → 글 목록(최신순) 맵을 만든다. */
+export function buildTagMap(posts: TaggedPost[]): Map<string, TaggedPost[]> {
+  const map = new Map<string, TaggedPost[]>();
+  for (const post of posts) {
+    for (const tag of post.tags) {
+      const list = map.get(tag);
+      if (list) list.push(post);
+      else map.set(tag, [post]);
+    }
+  }
+  for (const list of map.values()) {
+    list.sort((a, b) => b.date.getTime() - a.date.getTime());
+  }
+  return map;
+}
+
+/** 태그를 글 개수 내림차순(동점이면 이름순)으로 정렬해 반환한다. */
+export function sortedTagCounts(map: Map<string, TaggedPost[]>) {
+  return [...map.entries()]
+    .map(([tag, posts]) => ({ tag, count: posts.length }))
+    .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
+}
+
+export function postHref(post: TaggedPost) {
+  return `/${post.collection}/${post.id}/`;
+}
+
+export function tagHref(tag: string) {
+  return `/tags/${encodeURIComponent(tag)}/`;
+}


### PR DESCRIPTION
- /tags: 전체 태그 목록(글 개수, 개수 내림차순)
- /tags/[tag]: 태그별 글 목록(최신순, 컬렉션 배지)
- blog/weekly/archive 전체에서 태그 수집 (src/utils/tags.ts)
- 글 상세(blog·weekly·archive)에 클릭 가능한 태그 추가
- 헤더에 Tags 링크 추가