### PR TITLE
content: 본문 의미 분석 기반 태그 보강 + 정규화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# CLAUDE.md
+
+Astro 기반 개인 블로그. 콘텐츠 컬렉션: `blog`(직접 쓴 글), `weekly`(주간 개발 소식 요약), `archive`(예전 글). 스키마는 `src/content.config.ts`.
+
+## 콘텐츠 태그 컨벤션
+
+태그는 각 글 frontmatter 의 `tags:` (문자열 배열)에 들어가며, `/tags` 와 `/tags/[tag]` 로 탐색된다. 태그 시스템은 본문이 실제 다루는 주제를 반영하도록 설계되어 있다 (단순 `javascript`/`node`/`css` 나열 ❌).
+
+**표기 규칙**
+
+- 모두 소문자
+- 여러 단어는 kebab-case: `web-components`, `view-transitions`, `source-map`, `css-grid`
+- 단수형 명사
+- 글당 **4~8개**, 가장 핵심적인 구체 주제 위주
+- 과도하게 일반적/모호한 태그 금지: `web`, `etc`, `tutorial`, `tools`, `code`, `dev`, `programming`, `news`, `release`, `set`, `layout`, `transform`, `https`, `viewport`, `module`, `async` 등
+- 동의어는 표준형으로 통일: `nodejs`→`node`, `js`→`javascript`, `ts`→`typescript`, `webassembly`→`wasm`, `a11y`→`accessibility`, `db`→`database`, `grid`→`css-grid` (전체 매핑은 `scripts/normalize-tags.mjs` 의 `CANON`)
+- **기존 어휘 재사용 우선**: 새 태그를 만들기 전에 현재 쓰이는 태그(예: `/tags` 또는 기존 frontmatter)를 먼저 살펴 같은 개념이면 같은 표기를 쓴다.
+
+자주 쓰는 태그(참고): `node css javascript typescript react performance accessibility deno wasm v8 npm security electron animation testing devtools browser rust web-components eslint nextjs bun bundler angular astro vite svelte chrome go view-transitions http esm database svg pwa compiler esbuild vue vscode video websocket workers graphql html webgpu ...`
+
+## 새 글에 태그 달기
+
+1. 글 본문을 읽고, **실제로 다루는** 구체적 주제/기술 태그 4~8개를 frontmatter `tags:` 에 단다 (위 규칙 준수, 기존 어휘 재사용).
+2. 정규화 스크립트로 표기를 통일한다 (소문자/동의어 병합/약한 태그 제거/중복 제거/최대 8개, 멱등):
+   ```sh
+   node scripts/normalize-tags.mjs src/content/weekly/<새-글>.md   # 특정 파일
+   node scripts/normalize-tags.mjs                                  # 전체 재정규화
+   ```
+
+새 글이 한꺼번에 많이 들어와 일괄 태깅이 필요하면, 과거에 했던 방식을 그대로 재현하면 된다:
+각 글 본문을 의미 분석해 태그를 *제안*하고(병렬 에이전트 가능), 제안 결과를 `scripts/normalize-tags.mjs` 로 결정론적으로 적용한다. 이렇게 LLM 제안과 결정론적 적용을 분리해 일관성과 안전성을 확보한다.
+
+## 빌드 / 검증
+
+- `yarn build` (= `astro build`): 정적 빌드 + Pagefind 검색 인덱스 자동 생성.
+- 검색은 `astro dev` 에서 인덱스가 없어 동작하지 않을 수 있으므로, 로컬 확인은 `yarn build && yarn preview` 권장.
+- 검색은 `blog`+`weekly` 본문만 인덱싱한다 (레이아웃의 `data-pagefind-body`). 태그 페이지는 인덱싱 대상이 아니다.

--- a/scripts/normalize-tags.mjs
+++ b/scripts/normalize-tags.mjs
@@ -1,0 +1,132 @@
+// frontmatter 의 tags 를 프로젝트 컨벤션으로 정규화한다.
+// - 소문자, 여러 단어는 kebab-case, 동의어는 표준형으로 병합
+// - 너무 일반적/모호한 태그 제거, 중복 제거, 최대 8개
+// - tags 선언을 inline 배열 형태로 통일 (블록형도 처리)
+// 멱등하므로 반복 실행해도 안전하다.
+//
+// 사용:
+//   node scripts/normalize-tags.mjs                 # 전체 콘텐츠 스캔
+//   node scripts/normalize-tags.mjs path/to/post.md # 특정 파일만
+//
+// 새 글 추가 시: 본문이 실제로 다루는 구체적 주제 태그 4~8개를 달고
+// 이 스크립트를 돌려 표기를 통일한다. (자세한 컨벤션은 CLAUDE.md 참고)
+
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOTS = ['src/content/weekly', 'src/content/blog', 'src/content/archive'];
+
+const MAX_TAGS = 8;
+
+// 동의어 → 표준형
+const CANON = {
+  nodejs: 'node', 'node.js': 'node', js: 'javascript', ecmascript: 'javascript',
+  ts: 'typescript', reactjs: 'react', vuejs: 'vue', sveltejs: 'svelte',
+  webassembly: 'wasm', a11y: 'accessibility', db: 'database', devtool: 'devtools',
+  'web-component': 'web-components', 'view-transition': 'view-transitions',
+  'source-maps': 'source-map', githubactions: 'github-actions', 'ci/cd': 'ci',
+  grid: 'css-grid', fingerprinting: 'fingerprint', 'core-web-vitals': 'core-web-vital',
+};
+
+// 너무 일반적이거나 모호해 탐색에 도움이 안 되는 태그
+const DROP = new Set([
+  // 일반 명사/카테고리
+  'web', 'etc', 'stuff', 'tutorial', 'tutorials', 'tools', 'tool', 'code', 'dev',
+  'programming', 'misc', 'news', 'release', 'general', 'article', 'blog', 'guide',
+  // 모호/약한 태그
+  'set', 'layout', 'transform', 'https', 'viewport', 'module', 'async', 'asynchronous',
+]);
+
+function normalizeOne(raw) {
+  let s = String(raw).trim().toLowerCase();
+  s = s.replace(/\s+/g, '-').replace(/_/g, '-');
+  return CANON[s] || s;
+}
+
+function normalizeTags(tags) {
+  const seen = new Set();
+  const out = [];
+  for (const raw of tags) {
+    const t = normalizeOne(raw);
+    if (!t || DROP.has(t) || seen.has(t)) continue;
+    seen.add(t);
+    out.push(t);
+    if (out.length >= MAX_TAGS) break;
+  }
+  return out;
+}
+
+// frontmatter 에서 기존 tags(inline 또는 block)를 읽어온다.
+function readTags(fmLines) {
+  const i = fmLines.findIndex((l) => /^tags\s*:/.test(l));
+  if (i === -1) return { index: -1, end: -1, tags: [] };
+  const line = fmLines[i];
+  const inlineMatch = line.match(/^tags\s*:\s*\[(.*)\]\s*$/);
+  if (inlineMatch) {
+    const tags = inlineMatch[1]
+      .split(',')
+      .map((s) => s.trim().replace(/^["']|["']$/g, ''))
+      .filter(Boolean);
+    return { index: i, end: i, tags };
+  }
+  // block 형: tags:\n  - a\n  - b
+  let j = i + 1;
+  const tags = [];
+  while (j < fmLines.length && /^\s*-\s+/.test(fmLines[j])) {
+    tags.push(fmLines[j].replace(/^\s*-\s+/, '').trim().replace(/^["']|["']$/g, ''));
+    j++;
+  }
+  return { index: i, end: j - 1, tags };
+}
+
+function processFile(fp) {
+  const before = readFileSync(fp, 'utf8');
+  const m = before.match(/^(---\r?\n)([\s\S]*?)(\r?\n---\r?\n?)/);
+  if (!m) return 'no-frontmatter';
+  const [, open, fm, close] = m;
+  const body = before.slice(m[0].length);
+
+  const lines = fm.split('\n');
+  const { index, end, tags } = readTags(lines);
+  if (index === -1) return 'no-tags';
+
+  const norm = normalizeTags(tags);
+  if (norm.length === 0) return 'empty-after-normalize';
+
+  const newLine = `tags: [${norm.map((t) => `"${t}"`).join(', ')}]`;
+  lines.splice(index, end - index + 1, newLine);
+  const after = open + lines.join('\n') + close + body;
+
+  if (after !== before) {
+    writeFileSync(fp, after);
+    return 'updated';
+  }
+  return 'unchanged';
+}
+
+function collectFiles(args) {
+  if (args.length) return args;
+  const files = [];
+  for (const root of ROOTS) {
+    let entries;
+    try {
+      entries = readdirSync(root);
+    } catch (e) {
+      if (e.code === 'ENOENT') continue;
+      throw e;
+    }
+    for (const name of entries) {
+      if (/\.mdx?$/.test(name)) files.push(join(root, name));
+    }
+  }
+  return files;
+}
+
+const files = collectFiles(process.argv.slice(2));
+const stat = { updated: 0, unchanged: 0, 'no-tags': 0, 'no-frontmatter': 0, 'empty-after-normalize': 0 };
+for (const fp of files) stat[processFile(fp)]++;
+
+console.log(
+  `scanned: ${files.length}, updated: ${stat.updated}, unchanged: ${stat.unchanged}, ` +
+    `no-tags: ${stat['no-tags']}, no-frontmatter: ${stat['no-frontmatter']}, empty: ${stat['empty-after-normalize']}`
+);

--- a/src/content/archive/deno.md
+++ b/src/content/archive/deno.md
@@ -2,7 +2,7 @@
 title: Deno
 date: "2024-01-25T00:00:00+09:00"
 description: "Deno Archive"
-tags: ["javascript", "deno", "fresh"]
+tags: ["deno", "javascript", "typescript", "node", "runtime", "webgpu"]
 ---
 
 # deno

--- a/src/content/archive/typescript.md
+++ b/src/content/archive/typescript.md
@@ -2,7 +2,7 @@
 title: Typescript Archive
 date: "2023-11-20T00:00:00+09:00"
 description: "Typescript Update History"
-tags: ["javascript", "typescript"]
+tags: ["typescript", "javascript", "decorator", "jsx", "compiler"]
 ---
 
 ### **[2023.11.20 - Announcing TypeScript 5.3](https://devblogs.microsoft.com/typescript/announcing-typescript-5-3/)**

--- a/src/content/blog/About-Rendering-In-The-Browser.md
+++ b/src/content/blog/About-Rendering-In-The-Browser.md
@@ -2,7 +2,7 @@
 title: About Rendering In The Browser
 date: "2020-10-23T00:00:00+09:00"
 description: "브라우저의 렌더링에 대하여."
-tags: ["browser"]
+tags: ["browser", "rendering", "dom", "cssom", "performance", "css", "reflow", "compositing"]
 ---
 # 브라우저의 렌더링에 대하여
 

--- a/src/content/blog/Asynchronous.md
+++ b/src/content/blog/Asynchronous.md
@@ -2,7 +2,7 @@
 title: Asynchronous
 date: "2023-03-30T00:00:00+09:00"
 description: "Asynchronous"
-tags: ["Asynchronous"]
+tags: ["event-loop", "epoll", "io-uring", "node", "libuv", "rust"]
 ---
 
 # 비동기

--- a/src/content/blog/JS-Memory-Model.md
+++ b/src/content/blog/JS-Memory-Model.md
@@ -2,7 +2,7 @@
 title: JS Memory Model
 date: "2023-04-06T00:00:00+09:00"
 description: "JS Memory Modal by rsc"
-tags: ["javascript"]
+tags: ["javascript", "memory-model", "concurrency", "atomic", "shared-array-buffer", "web-worker"]
 ---
 
 # JS Memory Model

--- a/src/content/blog/Priority-Scheduler.md
+++ b/src/content/blog/Priority-Scheduler.md
@@ -2,7 +2,7 @@
 title: Priority Scheduler
 date: "2023-02-07T00:00:00+09:00"
 description: "Priority Scheduler"
-tags: ["browser"]
+tags: ["browser", "event-loop", "scheduler", "react", "performance", "javascript"]
 ---
 
 # 들어가기전에

--- a/src/content/blog/Software-Engineering-The-Soft-Parts_ko.md
+++ b/src/content/blog/Software-Engineering-The-Soft-Parts_ko.md
@@ -2,7 +2,7 @@
 title: Software Engineering - The Soft Parts 번역
 date: "2023-04-17T01:55:00+09:00"
 description: "Software Engineering - The Soft Parts 번역"
-tags: ["translate"]
+tags: ["software-engineering", "career", "mentoring", "communication", "documentation", "debugging"]
 ---
 
 원문 - [https://addyosmani.com/blog/software-engineering-soft-parts/](https://addyosmani.com/blog/software-engineering-soft-parts/)  

--- a/src/content/blog/WebClient_Performance_Improve.md
+++ b/src/content/blog/WebClient_Performance_Improve.md
@@ -2,7 +2,7 @@
 title: WebClient Performance Improve
 date: "2023-05-16T00:00:00+09:00"
 description: "WebClient Performance Improve. 웹의 성능은 무엇이고, 어떤걸 개선해야 하는지에 대한 개요 문서"
-tags: ["performance", "javascript", "css", "font", "image"]
+tags: ["performance", "core-web-vital", "css", "image", "font", "browser", "lighthouse"]
 ---
 
 # Requirement

--- a/src/content/weekly/dev-weekly-20210213.md
+++ b/src/content/weekly/dev-weekly-20210213.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-02-13
 date: "2021-02-13T09:00:00+09:00"
 description: "dev-weekly 2021-02-13"
-tags: ["javascript", "css", "node", "web", "typescript", "deno"]
+tags: ["deno", "css", "node", "animation", "font", "typescript", "security", "performance"]
 ---
 
 # Deno, CSS, Repl.it

--- a/src/content/weekly/dev-weekly-20210220.md
+++ b/src/content/weekly/dev-weekly-20210220.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-02-20
 date: "2021-02-20T09:00:00+09:00"
 description: "dev-weekly 2021-02-20"
-tags: ["javascript", "css", "node", "web", "typescript", "go"]
+tags: ["go", "css", "vite", "v8", "esbuild", "deno", "security", "bundler"]
 ---
 
 # go, CSS, Node

--- a/src/content/weekly/dev-weekly-20210227.md
+++ b/src/content/weekly/dev-weekly-20210227.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-02-27
 date: "2021-02-27T08:30:00+09:00"
 description: "dev-weekly 2021-02-27"
-tags: ["javascript", "css", "node", "web", "DB"]
+tags: ["css", "node", "database", "typescript", "performance", "storybook", "rust"]
 ---
 
 # CSS, Node, DB, ETC

--- a/src/content/weekly/dev-weekly-20210306.md
+++ b/src/content/weekly/dev-weekly-20210306.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-03-06
 date: "2021-03-06T08:40:00+09:00"
 description: "dev-weekly 2021-03-06"
-tags: ["javascript", "css", "node", "deno", "go"]
+tags: ["deno", "node", "css", "go", "v8", "electron", "websocket", "source-map"]
 ---
 
 # CSS, Node, Deno, GO, DB, ETC

--- a/src/content/weekly/dev-weekly-20210313.md
+++ b/src/content/weekly/dev-weekly-20210313.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-03-13
 date: "2021-03-13T11:30:00+09:00"
 description: "dev-weekly 2021-03-13"
-tags: ["javascript", "css", "node", "deno", "go"]
+tags: ["node", "go", "database", "svelte", "devtools", "esbuild", "sql"]
 ---
 
 # Node, GO, DB, ETC

--- a/src/content/weekly/dev-weekly-20210320.md
+++ b/src/content/weekly/dev-weekly-20210320.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-03-20
 date: "2021-03-20T09:10:00+09:00"
 description: "dev-weekly 2021-03-20"
-tags: ["javascript", "css", "go", "db"]
+tags: ["css", "v8", "go", "database", "performance", "regex", "tailwind", "react"]
 ---
 
 # CSS, DB, GO, Etc

--- a/src/content/weekly/dev-weekly-20210327.md
+++ b/src/content/weekly/dev-weekly-20210327.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-03-27
 date: "2021-03-27T10:00:00+09:00"
 description: "dev-weekly 2021-03-27"
-tags: ["javascript", "css", "go", "node"]
+tags: ["css", "node", "go", "svelte", "workers", "database", "eslint", "regex"]
 ---
 
 # CSS, Node, Go, Etc

--- a/src/content/weekly/dev-weekly-20210403.md
+++ b/src/content/weekly/dev-weekly-20210403.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-04-03
 date: "2021-04-03T09:10:00+09:00"
 description: "dev-weekly 2021-04-03"
-tags: ["javascript", "css", "go", "node", "deno"]
+tags: ["css", "node", "deno", "go", "typescript", "wasm", "v8", "angular"]
 ---
 
 # CSS, Node, Deno, Go

--- a/src/content/weekly/dev-weekly-20210410.md
+++ b/src/content/weekly/dev-weekly-20210410.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-04-10
 date: "2021-04-10T09:40:00+09:00"
 description: "dev-weekly 2021-04-10"
-tags: ["javascript", "css", "go", "db"]
+tags: ["css", "go", "node", "react", "database", "docker", "typescript", "performance"]
 ---
 
 # CSS, Go, Node

--- a/src/content/weekly/dev-weekly-20210417.md
+++ b/src/content/weekly/dev-weekly-20210417.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-04-17
 date: "2021-04-17T10:10:00+09:00"
 description: "dev-weekly 2021-04-17"
-tags: ["javascript", "css", "go", "db"]
+tags: ["css", "accessibility", "deno", "database", "sql", "typescript", "bundler", "devtools"]
 ---
 
 

--- a/src/content/weekly/dev-weekly-20210424.md
+++ b/src/content/weekly/dev-weekly-20210424.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-04-24
 date: "2021-04-24T09:30:00+09:00"
 description: "dev-weekly 2021-04-24"
-tags: ["javascript", "css", "go", "db"]
+tags: ["node", "css", "accessibility", "redis", "performance", "react", "babel", "v8"]
 ---
 
 # CSS, Node, DB, ETC

--- a/src/content/weekly/dev-weekly-20210501.md
+++ b/src/content/weekly/dev-weekly-20210501.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-05-01
 date: "2021-05-01T09:40:00+09:00"
 description: "dev-weekly 2021-05-01"
-tags: ["javascript", "css", "db"]
+tags: ["javascript", "css", "redis", "babel", "redux", "wasm", "performance", "rust"]
 ---
 
 # CSS, DB

--- a/src/content/weekly/dev-weekly-20210508.md
+++ b/src/content/weekly/dev-weekly-20210508.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-05-08
 date: "2021-05-08T11:30:00+09:00"
 description: "dev-weekly 2021-05-08"
-tags: ["javascript", "css", "node"]
+tags: ["node", "css", "v8", "web-components", "react", "sqlite", "devtools"]
 ---
 # Node, CSS
 

--- a/src/content/weekly/dev-weekly-20210515.md
+++ b/src/content/weekly/dev-weekly-20210515.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-05-15
 date: "2021-05-15T09:30:00+09:00"
 description: "dev-weekly 2021-05-15"
-tags: ["javascript", "css", "node"]
+tags: ["css", "accessibility", "deno", "angular", "babel", "wasm", "security", "svelte"]
 ---
 
 # CSS, Deno

--- a/src/content/weekly/dev-weekly-20210522.md
+++ b/src/content/weekly/dev-weekly-20210522.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-05-22
 date: "2021-05-22T14:30:00+09:00"
 description: "dev-weekly 2021-05-22"
-tags: ["javascript", "css", "node"]
+tags: ["css", "node", "wasm", "rust", "bundler", "typescript", "browser", "dom"]
 ---
 
 # CSS, Node

--- a/src/content/weekly/dev-weekly-20210529.md
+++ b/src/content/weekly/dev-weekly-20210529.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-05-29
 date: "2021-05-29T09:30:00+09:00"
 description: "dev-weekly 2021-05-29"
-tags: ["javascript", "css", "node"]
+tags: ["css", "accessibility", "node", "rust", "v8", "typescript", "jest", "react"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20210605.md
+++ b/src/content/weekly/dev-weekly-20210605.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-06-05
 date: "2021-06-05T10:10:00+09:00"
 description: "dev-weekly 2021-06-05"
-tags: ["javascript", "node"]
+tags: ["javascript", "node", "electron", "v8", "wasm", "svelte", "postgres"]
 ---
 
 # Node

--- a/src/content/weekly/dev-weekly-20210612.md
+++ b/src/content/weekly/dev-weekly-20210612.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-06-12
 date: "2021-06-12T08:30:00+09:00"
 description: "dev-weekly 2021-06-12"
-tags: ["javascript", "node"]
+tags: ["javascript", "node", "astro", "react", "vue", "go", "image", "devtools"]
 ---
 
 # Node

--- a/src/content/weekly/dev-weekly-20210619.md
+++ b/src/content/weekly/dev-weekly-20210619.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-06-19
 date: "2021-06-19T19:00:00+09:00"
 description: "dev-weekly 2021-06-19"
-tags: ["javascript", "node", "CSS"]
+tags: ["javascript", "node", "css", "performance", "accessibility", "nextjs", "deno", "v8"]
 ---
 
 # CSS, Node

--- a/src/content/weekly/dev-weekly-20210626.md
+++ b/src/content/weekly/dev-weekly-20210626.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-06-26
 date: "2021-06-26T09:00:00+09:00"
 description: "dev-weekly 2021-06-26"
-tags: ["javascript", "node", "CSS"]
+tags: ["javascript", "node", "css", "image", "performance", "ai", "monorepo"]
 ---
 
 # Node, CSS

--- a/src/content/weekly/dev-weekly-20210703.md
+++ b/src/content/weekly/dev-weekly-20210703.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-07-03
 date: "2021-07-03T09:30:00+09:00"
 description: "dev-weekly 2021-07-03"
-tags: ["javascript", "node", "css"]
+tags: ["javascript", "node", "css", "ai", "solid", "chrome", "http", "workers"]
 ---
 
 ## Node

--- a/src/content/weekly/dev-weekly-20210710.md
+++ b/src/content/weekly/dev-weekly-20210710.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-07-10
 date: "2021-07-10T14:00:00+09:00"
 description: "dev-weekly 2021-07-10"
-tags: ["javascript", "node", "deno", "go"]
+tags: ["javascript", "node", "deno", "go", "npm", "workers"]
 ---
 
 # Node, Deno

--- a/src/content/weekly/dev-weekly-20210717.md
+++ b/src/content/weekly/dev-weekly-20210717.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-07-17
 date: "2021-07-17T10:30:00+09:00"
 description: "dev-weekly 2021-07-17"
-tags: ["javascript", "node"]
+tags: ["javascript", "node", "v8", "deno", "docker", "database", "websocket"]
 ---
 
 # Node

--- a/src/content/weekly/dev-weekly-20210724.md
+++ b/src/content/weekly/dev-weekly-20210724.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-07-24
 date: "2021-07-24T09:00:00+09:00"
 description: "dev-weekly 2021-07-24"
-tags: ["javascript", "node", "css", "go"]
+tags: ["javascript", "node", "css", "go", "animation", "testing", "electron", "api"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20210731.md
+++ b/src/content/weekly/dev-weekly-20210731.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-07-31
 date: "2021-07-31T09:00:00+09:00"
 description: "dev-weekly 2021-07-31"
-tags: ["javascript", "node", "css"]
+tags: ["css", "accessibility", "node", "websocket", "v8", "performance", "electron", "yarn"]
 ---
 
 ## CSS

--- a/src/content/weekly/dev-weekly-20210807.md
+++ b/src/content/weekly/dev-weekly-20210807.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-08-07
 date: "2021-08-07T10:00:00+09:00"
 description: "dev-weekly 2021-08-07"
-tags: ["javascript", "node", "css"]
+tags: ["css", "flexbox", "vue", "node", "testing", "runtime", "javascript", "tailwind"]
 ---
 
 ## CSS

--- a/src/content/weekly/dev-weekly-20210814.md
+++ b/src/content/weekly/dev-weekly-20210814.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-08-14
 date: "2021-08-14T09:00:00+09:00"
 description: "dev-weekly 2021-08-14"
-tags: ["javascript", "node", "css"]
+tags: ["css", "v8", "deno", "vue", "nextjs", "typescript", "wasm", "performance"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20210821.md
+++ b/src/content/weekly/dev-weekly-20210821.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-08-21
 date: "2021-08-21T09:00:00+09:00"
 description: "dev-weekly 2021-08-21"
-tags: ["javascript", "css"]
+tags: ["css", "accessibility", "animation", "react-native", "typescript", "javascript"]
 ---
 
 

--- a/src/content/weekly/dev-weekly-20210828.md
+++ b/src/content/weekly/dev-weekly-20210828.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-08-28
 date: "2021-08-28T09:00:00+09:00"
 description: "dev-weekly 2021-08-28"
-tags: ["javascript", "css", "node"]
+tags: ["css", "view-transitions", "shadow-dom", "node", "typescript", "solid", "devtools", "react"]
 ---
 
 # CSS, Node

--- a/src/content/weekly/dev-weekly-20210904.md
+++ b/src/content/weekly/dev-weekly-20210904.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-09-04
 date: "2021-09-04T16:00:00+09:00"
 description: "dev-weekly 2021-09-04"
-tags: ["javascript", "css", "node"]
+tags: ["avif", "image", "accessibility", "electron", "svelte", "npm", "graphql", "css"]
 ---
 
 # CSS, Node, etc

--- a/src/content/weekly/dev-weekly-20210911.md
+++ b/src/content/weekly/dev-weekly-20210911.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-09-11
 date: "2021-09-11T11:00:00+09:00"
 description: "dev-weekly 2021-09-11"
-tags: ["javascript", "css"]
+tags: ["css", "accessibility", "animation", "devtools", "regex", "security"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20210918.md
+++ b/src/content/weekly/dev-weekly-20210918.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-09-18
 date: "2021-09-18T11:00:00+09:00"
 description: "dev-weekly 2021-09-18"
-tags: ["javascript", "node", "css"]
+tags: ["css", "animation", "accessibility", "node", "deno", "react", "graphql"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20210925.md
+++ b/src/content/weekly/dev-weekly-20210925.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-09-25
 date: "2021-09-25T11:00:00+09:00"
 description: "dev-weekly 2021-09-25"
-tags: ["javascript", "node", "css", "rust"]
+tags: ["javascript", "rust", "css", "v8", "wasm", "electron", "devtools", "typescript"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20211002.md
+++ b/src/content/weekly/dev-weekly-20211002.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-10-02
 date: "2021-10-02T11:00:00+09:00"
 description: "dev-weekly 2021-10-02"
-tags: ["javascript", "node", "css"]
+tags: ["javascript", "node", "css", "postgres", "eslint", "workers", "safari"]
 ---
 
 ### **[How To Optimize CSS for Peak Site Performance](https://kinsta.com/blog/optimize-css/)**

--- a/src/content/weekly/dev-weekly-20211009.md
+++ b/src/content/weekly/dev-weekly-20211009.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-10-09
 date: "2021-10-09T21:30:00+09:00"
 description: "dev-weekly 2021-10-09"
-tags: ["javascript", "node", "css"]
+tags: ["javascript", "css", "testing", "typescript", "regex", "rollup", "accessibility"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20211016.md
+++ b/src/content/weekly/dev-weekly-20211016.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-10-16
 date: "2021-10-16T10:00:00+09:00"
 description: "dev-weekly 2021-10-16"
-tags: ["javascript", "node", "css"]
+tags: ["javascript", "node", "css", "npm", "eslint", "bundler", "animation", "source-map"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20211023.md
+++ b/src/content/weekly/dev-weekly-20211023.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-10-23
 date: "2021-10-23T17:00:00+09:00"
 description: "dev-weekly 2021-10-23"
-tags: ["javascript", "node", "css"]
+tags: ["javascript", "node", "css", "angular", "testing", "wasm", "chrome", "image"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20211030.md
+++ b/src/content/weekly/dev-weekly-20211030.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-10-30
 date: "2021-10-30T17:00:00+09:00"
 description: "dev-weekly 2021-10-30"
-tags: ["javascript", "node", "css"]
+tags: ["javascript", "rust", "css", "nextjs", "security", "npm", "unicode", "git"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20211106.md
+++ b/src/content/weekly/dev-weekly-20211106.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-11-06
 date: "2021-11-06T10:00:00+09:00"
 description: "dev-weekly 2021-11-06"
-tags: ["javascript", "node", "css"]
+tags: ["javascript", "node", "css", "angular", "typescript", "security", "v8", "animation"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20211113.md
+++ b/src/content/weekly/dev-weekly-20211113.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-11-13
 date: "2021-11-13T10:00:00+09:00"
 description: "dev-weekly 2021-11-13"
-tags: ["javascript", "node", "css"]
+tags: ["javascript", "rust", "css", "svelte", "deno", "security", "unicode", "accessibility"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20211120.md
+++ b/src/content/weekly/dev-weekly-20211120.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-11-20
 date: "2021-11-20T09:00:00+09:00"
 description: "dev-weekly 2021-11-20"
-tags: ["javascript", "node", "css"]
+tags: ["css", "performance", "accessibility", "typescript", "webpack", "react", "electron", "node"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20211127.md
+++ b/src/content/weekly/dev-weekly-20211127.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-11-27
 date: "2021-11-27T10:00:00+09:00"
 description: "dev-weekly 2021-11-27"
-tags: ["css", "node", "javascript"]
+tags: ["css", "node", "remix", "prettier", "typescript", "rust", "wasm", "react"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20211204.md
+++ b/src/content/weekly/dev-weekly-20211204.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-12-04
 date: "2021-12-04T10:00:00+09:00"
 description: "dev-weekly 2021-12-04"
-tags: ["node", "javascript"]
+tags: ["node", "rust", "react", "angular", "vue", "svelte", "solid", "json"]
 ---
 
 

--- a/src/content/weekly/dev-weekly-20211211.md
+++ b/src/content/weekly/dev-weekly-20211211.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-12-11
 date: "2021-12-11T10:00:00+09:00"
 description: "dev-weekly 2021-12-11"
-tags: ["css", "node", "javascript"]
+tags: ["css", "performance", "graphql", "react", "tailwind", "devtools", "unicode", "node"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20211218.md
+++ b/src/content/weekly/dev-weekly-20211218.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-12-18
 date: "2021-12-18T11:00:00+09:00"
 description: "dev-weekly 2021-12-18"
-tags: ["css", "node", "javascript"]
+tags: ["css", "accessibility", "node", "deno", "http", "javascript", "react", "eslint"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20211225.md
+++ b/src/content/weekly/dev-weekly-20211225.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2021-12-25 - 연말이라 js, node 2주간 쉽니당
 date: "2021-12-25T10:00:00+09:00"
 description: "dev-weekly 2021-12-25"
-tags: ["css"]
+tags: ["css", "browser", "svg", "image", "pwa"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220108.md
+++ b/src/content/weekly/dev-weekly-20220108.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-01-08
 date: "2022-01-08T10:00:00+09:00"
 description: "dev-weekly 2022-01-08"
-tags: ["js"]
+tags: ["javascript", "vite", "nextjs", "rust", "wasm", "node", "solid", "animation"]
 ---
 
 ### **[2021's JavaScript *Rising Stars*](https://risingstars.js.org/2021/en)**

--- a/src/content/weekly/dev-weekly-20220115.md
+++ b/src/content/weekly/dev-weekly-20220115.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-01-15
 date: "2022-01-15T10:00:00+09:00"
 description: "dev-weekly 2022-01-15"
-tags: ["javascript", "node", "css"]
+tags: ["css", "node", "rust", "astro", "storybook", "javascript", "html"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220122.md
+++ b/src/content/weekly/dev-weekly-20220122.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-01-22
 date: "2022-01-22T09:00:00+09:00"
 description: "dev-weekly 2022-01-22"
-tags: ["javascript", "node", "css"]
+tags: ["css", "animation", "accessibility", "remix", "nextjs", "node", "structured-clone", "electron"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220129.md
+++ b/src/content/weekly/dev-weekly-20220129.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-01-29
 date: "2022-01-29T08:00:00+09:00"
 description: "dev-weekly 2022-01-29"
-tags: ["javascript", "node", "css", "go"]
+tags: ["typescript", "compiler", "go", "react", "devtools", "css", "fingerprint", "deno"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220205.md
+++ b/src/content/weekly/dev-weekly-20220205.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-02-05
 date: "2022-02-05T08:30:00+09:00"
 description: "dev-weekly 2022-02-05"
-tags: ["javascript", "css", "node", "go"]
+tags: ["css", "node", "v8", "electron", "babel", "regex", "wasm", "security"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220212.md
+++ b/src/content/weekly/dev-weekly-20220212.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-02-12
 date: "2022-02-12T08:30:00+09:00"
 description: "dev-weekly 2022-02-12"
-tags: ["javascript", "node"]
+tags: ["node", "electron", "vite", "vue", "compiler", "css-in-js", "webgl", "websocket"]
 ---
 
 # Node

--- a/src/content/weekly/dev-weekly-20220219.md
+++ b/src/content/weekly/dev-weekly-20220219.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-02-19
 date: "2022-02-19T19:47:00+09:00"
 description: "dev-weekly 2022-02-19"
-tags: ["javascript", "css", "node"]
+tags: ["css", "accessibility", "typescript", "node", "react-native", "nextjs", "monorepo"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220226.md
+++ b/src/content/weekly/dev-weekly-20220226.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-02-26
 date: "2022-02-26T10:30:00+09:00"
 description: "dev-weekly 2022-02-26"
-tags: ["javascript", "css", "node"]
+tags: ["css", "node", "javascript", "wasm", "http"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220305.md
+++ b/src/content/weekly/dev-weekly-20220305.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-03-05
 date: "2022-03-05T17:00:00+09:00"
 description: "dev-weekly 2022-03-05"
-tags: ["javascript", "css", "node"]
+tags: ["css", "safari", "devtools", "node", "typescript", "redux", "deno"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220312.md
+++ b/src/content/weekly/dev-weekly-20220312.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-03-12
 date: "2022-03-12T14:00:00+09:00"
 description: "dev-weekly 2022-03-12"
-tags: ["javascript", "css", "node"]
+tags: ["css", "web-components", "node", "websocket", "react", "webgpu", "typescript", "go"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220319.md
+++ b/src/content/weekly/dev-weekly-20220319.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-03-19
 date: "2022-03-19T11:00:00+09:00"
 description: "dev-weekly 2022-03-19"
-tags: ["javascript", "css", "node"]
+tags: ["css", "dialog", "accessibility", "node", "npm", "security", "deno", "nextjs"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20220326.md
+++ b/src/content/weekly/dev-weekly-20220326.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-03-26
 date: "2022-03-26T14:00:00+09:00"
 description: "dev-weekly 2022-03-26"
-tags: ["javascript", "css", "node"]
+tags: ["css", "dark-mode", "node", "npm", "security", "react", "parcel", "storybook"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20220402.md
+++ b/src/content/weekly/dev-weekly-20220402.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-04-02
 date: "2022-04-02T14:00:00+09:00"
 description: "dev-weekly 2022-04-02"
-tags: ["javascript", "css", "node"]
+tags: ["css", "performance", "react", "electron", "postgres", "decorator", "vscode"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220409.md
+++ b/src/content/weekly/dev-weekly-20220409.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-04-09
 date: "2022-04-09T21:50:00+09:00"
 description: "dev-weekly 2022-04-09"
-tags: ["javascript", "css", "node"]
+tags: ["font", "node", "testing", "react", "wasm", "rust", "astro", "storybook"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220416.md
+++ b/src/content/weekly/dev-weekly-20220416.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-04-16
 date: "2022-04-16T15:40:00+09:00"
 description: "dev-weekly 2022-04-16"
-tags: ["javascript", "css", "node"]
+tags: ["css", "accessibility", "typescript", "javascript", "react", "vscode"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220423.md
+++ b/src/content/weekly/dev-weekly-20220423.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-04-23
 date: "2022-04-23T09:00:00+09:00"
 description: "dev-weekly 2022-04-23"
-tags: ["javascript", "css", "node"]
+tags: ["image", "performance", "accessibility", "node", "v8", "wasm", "compiler"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220430.md
+++ b/src/content/weekly/dev-weekly-20220430.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-04-30
 date: "2022-04-30T09:50:00+09:00"
 description: "dev-weekly 2022-04-30"
-tags: ["javascript", "css", "node"]
+tags: ["css", "accessibility", "node", "deno", "bundler", "jest", "testing", "storybook"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220507.md
+++ b/src/content/weekly/dev-weekly-20220507.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-05-07
 date: "2022-05-07T23:45:00+09:00"
 description: "dev-weekly 2022-05-07"
-tags: ["javascript", "css", "node"]
+tags: ["css", "typography", "node", "fastify", "performance", "deno", "pwa", "rust"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220514.md
+++ b/src/content/weekly/dev-weekly-20220514.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-05-14
 date: "2022-05-14T20:00:00+09:00"
 description: "dev-weekly 2022-05-14"
-tags: ["javascript", "css", "node"]
+tags: ["css", "subgrid", "container-query", "node", "deno", "typescript", "performance", "react"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20220521.md
+++ b/src/content/weekly/dev-weekly-20220521.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-05-21
 date: "2022-05-21T22:00:00+09:00"
 description: "dev-weekly 2022-05-21"
-tags: ["javascript", "css", "node"]
+tags: ["css", "accessibility", "font", "node", "unicode", "playwright", "deno", "angular"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220528.md
+++ b/src/content/weekly/dev-weekly-20220528.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-05-28
 date: "2022-05-28T11:00:00+09:00"
 description: "dev-weekly 2022-05-28"
-tags: ["javascript", "css", "node"]
+tags: ["css", "accessibility", "typescript", "electron", "nextjs", "angular", "bundler", "service-worker"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220604.md
+++ b/src/content/weekly/dev-weekly-20220604.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-06-04
 date: "2022-06-04T14:00:00+09:00"
 description: "dev-weekly 2022-06-04"
-tags: ["javascript", "css", "node"]
+tags: ["css", "animation", "performance", "npm", "security", "deno", "angular", "video"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220611.md
+++ b/src/content/weekly/dev-weekly-20220611.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-06-11
 date: "2022-06-11T11:00:00+09:00"
 description: "dev-weekly 2022-06-11"
-tags: ["javascript", "css", "node"]
+tags: ["css", "animation", "fastify", "node", "esm", "web-components", "hydration", "vscode"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220618.md
+++ b/src/content/weekly/dev-weekly-20220618.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-06-18
 date: "2022-06-18T17:00:00+09:00"
 description: "dev-weekly 2022-06-18"
-tags: ["javascript", "css", "node"]
+tags: ["css", "accessibility", "node", "typescript", "monorepo", "react", "storybook", "prettier"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220625.md
+++ b/src/content/weekly/dev-weekly-20220625.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-06-25
 date: "2022-06-25T22:30:00+09:00"
 description: "dev-weekly 2022-06-25"
-tags: ["javascript", "css", "node"]
+tags: ["node", "deno", "puppeteer", "typescript", "react", "ai", "service-worker", "accessibility"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220702.md
+++ b/src/content/weekly/dev-weekly-20220702.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-07-02
 date: "2022-07-02T20:30:00+09:00"
 description: "dev-weekly 2022-07-02"
-tags: ["javascript", "css", "node"]
+tags: ["css", "node", "workers", "database", "nextjs", "vue", "http", "pnpm"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220709.md
+++ b/src/content/weekly/dev-weekly-20220709.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-07-09
 date: "2022-07-09T15:15:00+09:00"
 description: "dev-weekly 2022-07-09"
-tags: ["javascript", "css", "node"]
+tags: ["css", "node", "javascript", "variable-font", "bun", "npm", "vscode", "bundler"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20220716.md
+++ b/src/content/weekly/dev-weekly-20220716.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-07-16
 date: "2022-07-16T15:15:00+09:00"
 description: "dev-weekly 2022-07-16"
-tags: ["javascript", "node"]
+tags: ["node", "javascript", "esm", "vite", "nestjs", "esbuild", "react"]
 ---
 
 # Node

--- a/src/content/weekly/dev-weekly-20220723.md
+++ b/src/content/weekly/dev-weekly-20220723.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-07-23
 date: "2022-07-23T08:00:00+09:00"
 description: "dev-weekly 2022-07-23"
-tags: ["javascript", "node", "css"]
+tags: ["css", "node", "javascript", "mix-blend-mode", "aspect-ratio", "security", "video"]
 ---
 
 

--- a/src/content/weekly/dev-weekly-20220730.md
+++ b/src/content/weekly/dev-weekly-20220730.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-07-30
 date: "2022-07-30T16:00:00+09:00"
 description: "dev-weekly 2022-07-30"
-tags: ["javascript", "node", "css"]
+tags: ["css", "node", "javascript", "typescript", "npm", "security", "rust", "accessibility"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220806.md
+++ b/src/content/weekly/dev-weekly-20220806.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-08-06
 date: "2022-08-06T08:00:00+09:00"
 description: "dev-weekly 2022-08-06"
-tags: ["javascript", "node", "css"]
+tags: ["css", "node", "javascript", "accessibility", "npm", "electron", "go"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220813.md
+++ b/src/content/weekly/dev-weekly-20220813.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-08-13
 date: "2022-08-13T17:00:00+09:00"
 description: "dev-weekly 2022-08-13"
-tags: ["javascript", "node", "css"]
+tags: ["css", "node", "javascript", "typescript", "astro", "scroll-snap", "performance", "playwright"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220820.md
+++ b/src/content/weekly/dev-weekly-20220820.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-08-20
 date: "2022-08-20T10:00:00+09:00"
 description: "dev-weekly 2022-08-20"
-tags: ["css"]
+tags: ["css", "typography", "accessibility", "css-grid", "image", "performance"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220827.md
+++ b/src/content/weekly/dev-weekly-20220827.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-08-27
 date: "2022-08-27T12:00:00+09:00"
 description: "dev-weekly 2022-08-27"
-tags: ["javascript", "node", "css"]
+tags: ["css", "node", "javascript", "typescript", "container-query", "deno", "websocket", "storybook"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220903.md
+++ b/src/content/weekly/dev-weekly-20220903.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-09-03
 date: "2022-09-03T10:20:00+09:00"
 description: "dev-weekly 2022-09-03"
-tags: ["javascript", "css", "node",]
+tags: ["css", "node", "javascript", "react", "json", "css-grid", "compression", "service-worker"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20220910.md
+++ b/src/content/weekly/dev-weekly-20220910.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-09-10
 date: "2022-09-10T23:27:00+09:00"
 description: "dev-weekly 2022-09-10"
-tags: ["javascript", "css", "node",]
+tags: ["css", "node", "javascript", "animation", "performance", "testing", "react", "signal"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20220917.md
+++ b/src/content/weekly/dev-weekly-20220917.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-09-17
 date: "2022-09-17T16:00:00+09:00"
 description: "dev-weekly 2022-09-17"
-tags: ["javascript", "css", "node",]
+tags: ["css", "node", "javascript", "accessibility", "safari", "npm", "security", "canvas"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20220924.md
+++ b/src/content/weekly/dev-weekly-20220924.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-09-24
 date: "2022-09-24T12:30:00+09:00"
 description: "dev-weekly 2022-09-24"
-tags: ["javascript", "css", "node"]
+tags: ["css", "node", "javascript", "typescript", "svg", "npm", "ocr"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20221001.md
+++ b/src/content/weekly/dev-weekly-20221001.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-10-01
 date: "2022-10-01T17:00:00+09:00"
 description: "dev-weekly 2022-10-01"
-tags: ["javascript", "css", "node"]
+tags: ["css", "node", "javascript", "typescript", "security", "v8", "workers", "i18n"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20221008.md
+++ b/src/content/weekly/dev-weekly-20221008.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-10-08
 date: "2022-10-08T18:00:00+09:00"
 description: "dev-weekly 2022-10-08"
-tags: ["javascript", "css", "node"]
+tags: ["css", "node", "javascript", "typescript", "security", "docker", "http", "react"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20221015.md
+++ b/src/content/weekly/dev-weekly-20221015.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-10-15
 date: "2022-10-15T22:00:00+09:00"
 description: "dev-weekly 2022-10-15"
-tags: ["javascript", "css", "node"]
+tags: ["css", "node", "javascript", "typescript", "monorepo", "storybook", "graphql", "docker"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20221022.md
+++ b/src/content/weekly/dev-weekly-20221022.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-10-22
 date: "2022-10-22T11:00:00+09:00"
 description: "dev-weekly 2022-10-22"
-tags: ["javascript", "css", "node"]
+tags: ["css", "node", "javascript", "typescript", "svg", "accessibility", "security", "compiler"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20221029.md
+++ b/src/content/weekly/dev-weekly-20221029.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-10-29
 date: "2022-10-29T11:00:00+09:00"
 description: "dev-weekly 2022-10-29"
-tags: ["javascript", "css", "node", "devtool"]
+tags: ["css", "node", "nextjs", "deno", "turbopack", "devtools", "npm", "babel"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20221105.md
+++ b/src/content/weekly/dev-weekly-20221105.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-11-05
 date: "2022-11-05T14:00:00+09:00"
 description: "dev-weekly 2022-11-05"
-tags: ["javascript", "css", "node"]
+tags: ["typescript", "web-components", "turbopack", "vite", "remix", "rust", "svelte", "npm"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20221112.md
+++ b/src/content/weekly/dev-weekly-20221112.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-11-12
 date: "2022-11-12T17:00:00+09:00"
 description: "dev-weekly 2022-11-12"
-tags: ["javascript", "css", "node"]
+tags: ["css", "node", "security", "view-transitions", "rust", "bundler", "chrome", "gatsby"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20221119.md
+++ b/src/content/weekly/dev-weekly-20221119.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-11-19
 date: "2022-11-19T12:00:00+09:00"
 description: "dev-weekly 2022-11-19"
-tags: ["javascript", "css", "node"]
+tags: ["css", "typescript", "deno", "node", "angular", "vue", "nextjs", "testing"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20221126.md
+++ b/src/content/weekly/dev-weekly-20221126.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-11-26
 date: "2022-11-26T11:50:00+09:00"
 description: "dev-weekly 2022-11-26"
-tags: ["javascript", "css", "node"]
+tags: ["css", "accessibility", "regex", "eslint", "react", "testing", "esm", "wasm"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20221203.md
+++ b/src/content/weekly/dev-weekly-20221203.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-12-03
 date: "2022-12-03T19:30:00+09:00"
 description: "dev-weekly 2022-12-03"
-tags: ["javascript", "css", "node"]
+tags: ["accessibility", "performance", "vite", "electron", "storybook", "v8", "i18n", "prisma"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20221210.md
+++ b/src/content/weekly/dev-weekly-20221210.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-12-10
 date: "2022-12-10T19:30:00+09:00"
 description: "dev-weekly 2022-12-10"
-tags: ["javascript", "css", "node"]
+tags: ["css", "accessibility", "vite", "npm", "prisma", "testing", "ai", "bun"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20221217.md
+++ b/src/content/weekly/dev-weekly-20221217.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2022-12-17
 date: "2022-12-17T10:40:00+09:00"
 description: "dev-weekly 2022-12-17"
-tags: ["javascript", "css", "node"]
+tags: ["css", "accessibility", "svelte", "javascript", "performance", "react", "node"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20230107.md
+++ b/src/content/weekly/dev-weekly-20230107.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-01-07
 date: "2023-01-07T13:00:00+09:00"
 description: "dev-weekly 2023-01-07"
-tags: ["javascript", "css", "node"]
+tags: ["javascript", "node", "go", "electron", "isomorphic", "turborepo", "bun"]
 ---
 # Node
 

--- a/src/content/weekly/dev-weekly-20230114.md
+++ b/src/content/weekly/dev-weekly-20230114.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-01-14
 date: "2023-01-14T16:20:00+09:00"
 description: "dev-weekly 2023-01-14"
-tags: ["javascript", "node"]
+tags: ["javascript", "node", "typescript", "react", "json", "scheduler", "testing", "github-copilot"]
 ---
 # Node
 

--- a/src/content/weekly/dev-weekly-20230121.md
+++ b/src/content/weekly/dev-weekly-20230121.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-01-21
 date: "2023-01-21T15:20:00+09:00"
 description: "dev-weekly 2023-01-21"
-tags: ["javascript", "node", "css"]
+tags: ["css", "node", "javascript", "bun", "wasm", "jest", "container-query", "esbuild"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20230128.md
+++ b/src/content/weekly/dev-weekly-20230128.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-01-28
 date: "2023-01-28T12:10:00+09:00"
 description: "dev-weekly 2023-01-28"
-tags: ["javascript", "node", "css"]
+tags: ["css", "node", "javascript", "typescript", "astro", "deno", "rust", "wasm"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20230204.md
+++ b/src/content/weekly/dev-weekly-20230204.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-02-04
 date: "2023-02-04T12:20:00+09:00"
 description: "dev-weekly 2023-02-04"
-tags: ["javascript", "node", "css"]
+tags: ["css", "node", "javascript", "react", "go", "tc39", "web-components", "container-query"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20230211.md
+++ b/src/content/weekly/dev-weekly-20230211.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-02-11
 date: "2023-02-11T17:20:00+09:00"
 description: "dev-weekly 2023-02-11"
-tags: ["javascript", "css", "node"]
+tags: ["css", "node", "javascript", "typescript", "eslint", "responsive-design", "electron", "favicon"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20230218.md
+++ b/src/content/weekly/dev-weekly-20230218.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-02-18
 date: "2023-02-18T12:40:00+09:00"
 description: "dev-weekly 2023-02-18"
-tags: ["javascript", "css", "node"]
+tags: ["css", "node", "javascript", "deno", "angular", "performance", "security", "pwa"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20230225.md
+++ b/src/content/weekly/dev-weekly-20230225.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-02-25
 date: "2023-02-25T14:00:00+09:00"
 description: "dev-weekly 2023-02-25"
-tags: ["javascript", "css", "node"]
+tags: ["css", "node", "javascript", "font", "nextjs", "chrome", "accessibility", "storybook"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20230304.md
+++ b/src/content/weekly/dev-weekly-20230304.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-03-04
 date: "2023-03-04T14:00:00+09:00"
 description: "dev-weekly 2023-03-04"
-tags: ["javascript", "css", "node", "etc"]
+tags: ["css", "node", "javascript", "typescript", "deno", "npm", "security"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20230311.md
+++ b/src/content/weekly/dev-weekly-20230311.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-03-11
 date: "2023-03-11T11:30:00+09:00"
 description: "dev-weekly 2023-03-11"
-tags: ["javascript", "css", "node"]
+tags: ["css", "node", "javascript", "typescript", "react", "performance", "jest", "v8"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20230318.md
+++ b/src/content/weekly/dev-weekly-20230318.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-03-18
 date: "2023-03-18T12:40:00+09:00"
 description: "dev-weekly 2023-03-18"
-tags: ["javascript", "css", "node"]
+tags: ["css", "animation", "node", "electron", "typescript", "view-transitions", "react", "ml"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20230325.md
+++ b/src/content/weekly/dev-weekly-20230325.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-03-25
 date: "2023-03-25T12:00:00+09:00"
 description: "dev-weekly 2023-03-25"
-tags: ["javascript", "css", "node"]
+tags: ["css", "node", "npm", "deno", "javascript", "react", "astro", "testing"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20230401.md
+++ b/src/content/weekly/dev-weekly-20230401.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-04-01
 date: "2023-04-01T14:40:00+09:00"
 description: "dev-weekly 2023-04-01"
-tags: ["javascript", "css", "node", "web", "typescript"]
+tags: ["css", "accessibility", "node", "javascript", "typescript", "react", "safari", "web-components"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20230408.md
+++ b/src/content/weekly/dev-weekly-20230408.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-04-08
 date: "2023-04-08T14:40:00+09:00"
 description: "dev-weekly 2023-04-08"
-tags: ["javascript", "css"]
+tags: ["css", "angular", "react", "wasm", "v8", "chrome", "electron", "pwa"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20230415.md
+++ b/src/content/weekly/dev-weekly-20230415.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-04-15
 date: "2023-04-15T11:00:00+09:00"
 description: "dev-weekly 2023-04-15"
-tags: ["javascript", "css", "node"]
+tags: ["css", "font", "accessibility", "html", "node", "testing", "javascript", "security"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20230422.md
+++ b/src/content/weekly/dev-weekly-20230422.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-04-22
 date: "2023-04-22T10:00:00+09:00"
 description: "dev-weekly 2023-04-22"
-tags: ["javascript", "css", "node", "infra", "etc"]
+tags: ["node", "css", "accessibility", "performance", "vite", "typescript", "http", "security"]
 ---
 # Node
 

--- a/src/content/weekly/dev-weekly-20230429.md
+++ b/src/content/weekly/dev-weekly-20230429.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-04-29
 date: "2023-04-29T12:30:00+09:00"
 description: "dev-weekly 2023-04-29"
-tags: ["javascript", "css", "node"]
+tags: ["css", "node", "javascript", "rust", "grpc", "pwa", "devtools", "graphql"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20230505.md
+++ b/src/content/weekly/dev-weekly-20230505.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-05-05
 date: "2023-05-05T17:00:00+09:00"
 description: "dev-weekly 2023-05-05"
-tags: ["javascript", "css", "node", "etc"]
+tags: ["css", "node", "javascript", "deno", "angular", "pwa", "react-native", "performance"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20230513.md
+++ b/src/content/weekly/dev-weekly-20230513.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-05-13
 date: "2023-05-13T12:40:00+09:00"
 description: "dev-weekly 2023-05-13"
-tags: ["javascript", "css", "node", "etc"]
+tags: ["css", "node", "javascript", "nextjs", "svelte", "react", "bundler", "accessibility"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20230520.md
+++ b/src/content/weekly/dev-weekly-20230520.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-05-20
 date: "2023-05-20T09:00:00+09:00"
 description: "dev-weekly 2023-05-20"
-tags: ["javascript", "css", "node", "etc"]
+tags: ["css", "node", "javascript", "unicode", "react", "v8", "performance", "accessibility"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20230527.md
+++ b/src/content/weekly/dev-weekly-20230527.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-05-27
 date: "2023-05-27T12:00:00+09:00"
 description: "dev-weekly 2023-05-27"
-tags: ["javascript", "css", "node"]
+tags: ["css", "node", "javascript", "typescript", "deno", "wasm", "performance", "astro"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20230602.md
+++ b/src/content/weekly/dev-weekly-20230602.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-06-02
 date: "2023-06-02T23:50:00+09:00"
 description: "dev-weekly 2023-06-02"
-tags: ["javascript", "css", "node", "go", "etc"]
+tags: ["css", "node", "javascript", "go", "bun", "wasm", "websocket", "performance"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20230610.md
+++ b/src/content/weekly/dev-weekly-20230610.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-06-10
 date: "2023-06-10T11:00:00+09:00"
 description: "dev-weekly 2023-06-10"
-tags: ["javascript", "css", "node", "etc"]
+tags: ["css", "node", "javascript", "wasm", "regex", "react", "eslint", "testing"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20230617.md
+++ b/src/content/weekly/dev-weekly-20230617.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-06-17
 date: "2023-06-17T16:10:00+09:00"
 description: "dev-weekly 2023-06-17"
-tags: ["javascript", "css", "node", "go", "etc"]
+tags: ["css", "node", "javascript", "typescript", "bun", "angular", "security", "accessibility"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20230624.md
+++ b/src/content/weekly/dev-weekly-20230624.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-06-24
 date: "2023-06-24T12:00:00+09:00"
 description: "dev-weekly 2023-06-24"
-tags: ["javascript", "css", "node"]
+tags: ["css", "node", "svelte", "deno", "graphql", "http", "performance", "event-loop"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20230630.md
+++ b/src/content/weekly/dev-weekly-20230630.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-06-30
 date: "2023-06-30T12:40:00+09:00"
 description: "dev-weekly 2023-06-30"
-tags: ["javascript", "css", "node", "etc"]
+tags: ["css", "node", "typescript", "nestjs", "npm", "testing", "devtools", "performance"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20230708.md
+++ b/src/content/weekly/dev-weekly-20230708.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-07-08
 date: "2023-07-08T15:55:00+09:00"
 description: "dev-weekly 2023-07-08"
-tags: ["javascript", "css", "node", "etc"]
+tags: ["css", "typescript", "deno", "regex", "view-transitions", "web-components", "vite", "svg"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20230715.md
+++ b/src/content/weekly/dev-weekly-20230715.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-07-15
 date: "2023-07-15T15:15:00+09:00"
 description: "dev-weekly 2023-07-15"
-tags: ["javascript", "css", "node"]
+tags: ["css", "node", "typescript", "database", "prettier", "accessibility", "electron"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20230722.md
+++ b/src/content/weekly/dev-weekly-20230722.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-07-22
 date: "2023-07-22T09:00:00+09:00"
 description: "dev-weekly 2023-07-22"
-tags: ["javascript", "css", "node"]
+tags: ["css", "node", "rust", "react", "storybook", "wasm", "performance", "svg"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20230729.md
+++ b/src/content/weekly/dev-weekly-20230729.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-07-29
 date: "2023-07-29T16:30:00+09:00"
 description: "dev-weekly 2023-07-29"
-tags: ["javascript", "css", "node"]
+tags: ["css", "node", "typescript", "bun", "react", "wasm", "astro", "security"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20230805.md
+++ b/src/content/weekly/dev-weekly-20230805.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-08-05
 date: "2023-08-05T16:00:00+09:00"
 description: "dev-weekly 2023-08-05"
-tags: ["javascript", "css", "node"]
+tags: ["css", "node", "typescript", "v8", "wasm", "react", "animation", "performance"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20230812.md
+++ b/src/content/weekly/dev-weekly-20230812.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-08-12
 date: "2023-08-12T11:30:00+09:00"
 description: "dev-weekly 2023-08-12"
-tags: ["javascript", "node"]
+tags: ["node", "deno", "wasm", "esm", "electron", "performance", "webgpu", "image"]
 ---
 # Node
 

--- a/src/content/weekly/dev-weekly-20230819.md
+++ b/src/content/weekly/dev-weekly-20230819.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-08-19
 date: "2023-08-19T17:35:00+09:00"
 description: "dev-weekly 2023-08-19"
-tags: ["javascript", "node", "css"]
+tags: ["css", "animation", "view-transitions", "font", "deno", "rollup", "devtools", "chrome"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20230902.md
+++ b/src/content/weekly/dev-weekly-20230902.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-09-02
 date: "2023-09-02T11:40:00+09:00"
 description: "dev-weekly 2023-09-02"
-tags: ["javascript", "node", "css"]
+tags: ["css", "web-components", "node", "npx", "accessibility", "docker", "pnpm"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20230909.md
+++ b/src/content/weekly/dev-weekly-20230909.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-09-09
 date: "2023-09-09T11:30:00+09:00"
 description: "dev-weekly 2023-09-09"
-tags: ["javascript", "node", "css"]
+tags: ["css", "view-transitions", "astro", "node", "npm", "security", "firefox"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20230916.md
+++ b/src/content/weekly/dev-weekly-20230916.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-09-16
 date: "2023-09-16T21:16:00+09:00"
 description: "dev-weekly 2023-09-16"
-tags: ["javascript", "node", "css"]
+tags: ["bun", "jpeg", "image", "javascript", "playwright", "safari", "font", "wasm"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20230923.md
+++ b/src/content/weekly/dev-weekly-20230923.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-09-23
 date: "2023-09-23T10:45:00+09:00"
 description: "dev-weekly 2023-09-23"
-tags: ["javascript", "node", "css"]
+tags: ["css", "animation", "bun", "deno", "safari", "minification", "nextjs", "reactivity"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20230930.md
+++ b/src/content/weekly/dev-weekly-20230930.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-09-30
 date: "2023-09-30T11:35:00+09:00"
 description: "dev-weekly 2023-09-30"
-tags: ["javascript", "node", "css"]
+tags: ["css", "animation", "node", "polyfill", "fastify", "jwt", "font", "http"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20231007.md
+++ b/src/content/weekly/dev-weekly-20231007.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-10-07
 date: "2023-10-07T10:40:00+09:00"
 description: "dev-weekly 2023-10-07"
-tags: ["javascript", "node", "browser"]
+tags: ["webgpu", "wasm", "service-worker", "web-components", "npm", "security", "crdt", "performance"]
 ---
 # Node
 

--- a/src/content/weekly/dev-weekly-20231014.md
+++ b/src/content/weekly/dev-weekly-20231014.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-10-14
 date: "2023-10-14T11:00:00+09:00"
 description: "dev-weekly 2023-10-14"
-tags: ["javascript", "CSS", "node", "v8", "ddos"]
+tags: ["css", "bun", "node", "deno", "webrtc", "security", "v8", "bundler"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20231021.md
+++ b/src/content/weekly/dev-weekly-20231021.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-10-21
 date: "2023-10-21T13:10:00+09:00"
 description: "dev-weekly 2023-10-21"
-tags: ["javascript", "CSS", "node", "unicode"]
+tags: ["css", "node", "v8", "astro", "source-map", "angular", "unicode"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20231028.md
+++ b/src/content/weekly/dev-weekly-20231028.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-10-28
 date: "2023-10-28T09:50:00+09:00"
 description: "dev-weekly 2023-10-28"
-tags: ["javascript", "CSS", "node", "eslint"]
+tags: ["css", "node", "yarn", "nextjs", "web-components", "eslint", "prettier", "react"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20231104.md
+++ b/src/content/weekly/dev-weekly-20231104.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-11-04
 date: "2023-11-04T11:20:00+09:00"
 description: "dev-weekly 2023-11-04"
-tags: ["javascript", "CSS", "node", "browser"]
+tags: ["css", "rust", "service-worker", "web-components", "performance", "remix", "vite", "video"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20231111.md
+++ b/src/content/weekly/dev-weekly-20231111.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-11-11
 date: "2023-11-11T11:20:00+09:00"
 description: "dev-weekly 2023-11-11"
-tags: ["javascript", "CSS", "node", "eslint"]
+tags: ["css", "node", "security", "deno", "react", "angular", "eslint", "typescript"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20231118.md
+++ b/src/content/weekly/dev-weekly-20231118.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-11-18
 date: "2023-11-18T15:45:00+09:00"
 description: "dev-weekly 2023-11-18"
-tags: ["javascript", "CSS", "node", "v8"]
+tags: ["css", "node", "web-components", "react", "prettier", "devtools", "bundler", "v8"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20231125.md
+++ b/src/content/weekly/dev-weekly-20231125.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-11-25
 date: "2023-11-25T14:50:00+09:00"
 description: "dev-weekly 2023-11-25"
-tags: ["javascript", "CSS", "node"]
+tags: ["css", "typescript", "vite", "performance", "image", "redux", "accessibility"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20231202.md
+++ b/src/content/weekly/dev-weekly-20231202.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-12-02
 date: "2023-12-02T11:10:00+09:00"
 description: "dev-weekly 2023-12-02"
-tags: ["javascript", "CSS", "node", "WASM"]
+tags: ["css", "animation", "node", "deno", "performance", "astro", "testing", "wasm"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20231209.md
+++ b/src/content/weekly/dev-weekly-20231209.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-12-09
 date: "2023-12-09T18:38:00+09:00"
 description: "dev-weekly 2023-12-09"
-tags: ["javascript", "CSS", "node", "a11y", "v8"]
+tags: ["css", "accessibility", "node", "astro", "electron", "v8", "react", "view-transitions"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20231216.md
+++ b/src/content/weekly/dev-weekly-20231216.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-12-16
 date: "2023-12-16T16:21:00+09:00"
 description: "dev-weekly 2023-12-16"
-tags: ["javascript", "CSS", "node", "vscode", "browser"]
+tags: ["css", "javascript", "node", "bun", "deno", "animation", "eslint", "devtools"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20231223.md
+++ b/src/content/weekly/dev-weekly-20231223.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2023-12-23
 date: "2023-12-23T17:10:00+09:00"
 description: "dev-weekly 2023-12-23"
-tags: ["javascript", "CSS", "browser", "v8"]
+tags: ["css", "javascript", "web-components", "svelte", "v8", "vite", "firefox", "wasm"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20240106.md
+++ b/src/content/weekly/dev-weekly-20240106.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-01-06
 date: "2024-01-06T13:20:00+09:00"
 description: "dev-weekly 2024-01-06"
-tags: ["javascript", "typescript"]
+tags: ["javascript", "typescript", "node", "sql", "react", "vue"]
 ---
 # Javascript
 

--- a/src/content/weekly/dev-weekly-20240113.md
+++ b/src/content/weekly/dev-weekly-20240113.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-01-13
 date: "2024-01-13T10:40:00+09:00"
 description: "dev-weekly 2024-01-13"
-tags: ["javascript", "CSS", "a11y", "node", "Benchmark"]
+tags: ["javascript", "css", "accessibility", "node", "performance", "testing", "regex", "astro"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20240120.md
+++ b/src/content/weekly/dev-weekly-20240120.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-01-20
 date: "2024-01-20T13:30:00+09:00"
 description: "dev-weekly 2024-01-20"
-tags: ["javascript", "CSS", "node"]
+tags: ["javascript", "css", "node", "npm", "pwa", "web-components", "testing", "accessibility"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20240127.md
+++ b/src/content/weekly/dev-weekly-20240127.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-01-27
 date: "2024-01-27T12:00:00+09:00"
 description: "dev-weekly 2024-01-27"
-tags: ["javascript", "node"]
+tags: ["javascript", "node", "astro", "nextjs", "api", "json", "runtime"]
 ---
 
 # Node

--- a/src/content/weekly/dev-weekly-20240203.md
+++ b/src/content/weekly/dev-weekly-20240203.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-02-03
 date: "2024-02-03T10:40:00+09:00"
 description: "dev-weekly 2024-02-03"
-tags: ["javascript", "node", "css", "deno"]
+tags: ["javascript", "typescript", "node", "css", "deno", "animation", "performance", "testing"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20240210.md
+++ b/src/content/weekly/dev-weekly-20240210.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-02-10
 date: "2024-02-10T11:30:00+09:00"
 description: "dev-weekly 2024-02-10"
-tags: ["javascript", "node"]
+tags: ["javascript", "node", "npm", "performance", "storybook", "compiler", "vite"]
 ---
 # Node
 

--- a/src/content/weekly/dev-weekly-20240217.md
+++ b/src/content/weekly/dev-weekly-20240217.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-02-17
 date: "2024-02-17T20:00:00+09:00"
 description: "dev-weekly 2024-02-17"
-tags: ["javascript", "css"]
+tags: ["css", "react", "pwa", "web-components", "tc39", "safari", "astro"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20240224.md
+++ b/src/content/weekly/dev-weekly-20240224.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-02-24
 date: "2024-02-24T17:00:00+09:00"
 description: "dev-weekly 2024-02-24"
-tags: ["javascript", "css", "chrome", "ai"]
+tags: ["css", "view-transitions", "web-components", "browser", "devtools", "chrome", "ai", "bun"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20240302.md
+++ b/src/content/weekly/dev-weekly-20240302.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-03-02
 date: "2024-03-02T11:10:00+09:00"
 description: "dev-weekly 2024-03-02"
-tags: ["javascript", "css", "node"]
+tags: ["css", "animation", "node", "jsr", "deno", "wasm", "postgres", "typescript"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20240309.md
+++ b/src/content/weekly/dev-weekly-20240309.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-03-09
 date: "2024-03-09T19:00:00+09:00"
 description: "dev-weekly 2024-03-09"
-tags: ["javascript", "node"]
+tags: ["jsr", "deno", "webgpu", "performance", "react", "testing", "typescript"]
 ---
 # Node
 

--- a/src/content/weekly/dev-weekly-20240316.md
+++ b/src/content/weekly/dev-weekly-20240316.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-03-16
 date: "2024-03-16T10:00:00+09:00"
 description: "dev-weekly 2024-03-16"
-tags: ["javascript", "node", "css", "ai", "github"]
+tags: ["css", "design-system", "node", "runtime", "performance", "v8", "ai", "github"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20240323.md
+++ b/src/content/weekly/dev-weekly-20240323.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-03-23
 date: "2024-03-23T20:00:00+09:00"
 description: "dev-weekly 2024-03-23"
-tags: ["javascript", "node", "css", "w3c"]
+tags: ["css", "safari", "node", "esm", "localstorage", "svg", "webnn"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20240330.md
+++ b/src/content/weekly/dev-weekly-20240330.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-03-30
 date: "2024-03-30T22:55:00+09:00"
 description: "dev-weekly 2024-03-30"
-tags: ["javascript", "css", "node"]
+tags: ["css", "i18n", "node", "npm", "v8", "performance", "esbuild", "chrome"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20240405.md
+++ b/src/content/weekly/dev-weekly-20240405.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-04-05
 date: "2025-04-05T18:01:00+09:00"
 description: "dev-weekly 2025-04-05"
-tags: ["javascript", "css", "node"]
+tags: ["css", "animation", "runtime", "v8", "node", "express"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20240406.md
+++ b/src/content/weekly/dev-weekly-20240406.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-04-06
 date: "2024-04-06T20:30:00+09:00"
 description: "dev-weekly 2024-04-06"
-tags: ["javascript", "node"]
+tags: ["node", "javascript", "bun", "deno", "jpeg", "web-components", "browser"]
 ---
 
 # Node

--- a/src/content/weekly/dev-weekly-20240413.md
+++ b/src/content/weekly/dev-weekly-20240413.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-04-13
 date: "2024-04-13T16:15:00+09:00"
 description: "dev-weekly 2024-04-13"
-tags: ["javascript", "node"]
+tags: ["node", "javascript", "testing", "eslint", "css", "accessibility", "esbuild"]
 ---
 # Node
 

--- a/src/content/weekly/dev-weekly-20240420.md
+++ b/src/content/weekly/dev-weekly-20240420.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-04-20
 date: "2024-04-20T23:15:00+09:00"
 description: "dev-weekly 2024-04-20"
-tags: ["javascript", "node"]
+tags: ["node", "javascript", "performance", "devtools", "react", "nextjs", "view-transitions"]
 ---
 # Node
 

--- a/src/content/weekly/dev-weekly-20240427.md
+++ b/src/content/weekly/dev-weekly-20240427.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-04-27
 date: "2024-04-27T15:00:00+09:00"
 description: "dev-weekly 2024-04-27"
-tags: ["javascript", "node", "css"]
+tags: ["node", "javascript", "css", "html", "react", "npm", "electron"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20240504.md
+++ b/src/content/weekly/dev-weekly-20240504.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-05-04
 date: "2024-05-04T15:00:00+09:00"
 description: "dev-weekly 2024-05-04"
-tags: ["javascript", "node", "css"]
+tags: ["node", "javascript", "css", "react", "animation", "browser", "typescript"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20240511.md
+++ b/src/content/weekly/dev-weekly-20240511.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-05-11
 date: "2024-05-11T14:20:00+09:00"
 description: "dev-weekly 2024-05-11"
-tags: ["javascript", "node"]
+tags: ["node", "javascript", "typescript", "npm", "esbuild", "v8"]
 ---
 
 # Node

--- a/src/content/weekly/dev-weekly-20240518.md
+++ b/src/content/weekly/dev-weekly-20240518.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-05-18
 date: "2024-05-18T15:00:00+09:00"
 description: "dev-weekly 2024-05-18"
-tags: ["javascript", "node", "css", "chrome"]
+tags: ["node", "javascript", "css", "chrome", "react", "devtools", "workers", "ai"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20240525.md
+++ b/src/content/weekly/dev-weekly-20240525.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-05-25
 date: "2024-05-25T16:45:00+09:00"
 description: "dev-weekly 2024-05-25"
-tags: ["javascript", "node"]
+tags: ["node", "javascript", "react", "nextjs", "testing", "solid", "angular"]
 ---
 # Node
 

--- a/src/content/weekly/dev-weekly-20240531.md
+++ b/src/content/weekly/dev-weekly-20240531.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-05-31
 date: "2025-05-31T21:54:00+09:00"
 description: "dev-weekly 2025-05-31"
-tags: ["node","css", "javascript", "chrome"]
+tags: ["node", "javascript", "temporal", "remix", "react", "html", "firefox", "captcha"]
 ---
 
 # Nodejs

--- a/src/content/weekly/dev-weekly-20240601.md
+++ b/src/content/weekly/dev-weekly-20240601.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-06-01
 date: "2024-06-01T20:48:00+09:00"
 description: "dev-weekly 2024-06-01"
-tags: ["javascript", "node"]
+tags: ["node", "javascript", "esbuild", "astro", "accessibility", "responsive-design", "typescript"]
 ---
 
 # Node

--- a/src/content/weekly/dev-weekly-20240608.md
+++ b/src/content/weekly/dev-weekly-20240608.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-06-08
 date: "2024-06-08T12:10:00+09:00"
 description: "dev-weekly 2024-06-08"
-tags: ["javascript", "node"]
+tags: ["node", "javascript", "performance", "dom", "turborepo", "wasm", "accessibility"]
 ---
 # Node
 

--- a/src/content/weekly/dev-weekly-20240615.md
+++ b/src/content/weekly/dev-weekly-20240615.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-06-15
 date: "2024-06-15T17:38:00+09:00"
 description: "dev-weekly 2024-06-15"
-tags: ["css", "browser"]
+tags: ["css", "browser", "animation", "view-transitions", "safari", "lighthouse", "performance", "firefox"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20240622.md
+++ b/src/content/weekly/dev-weekly-20240622.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-06-22
 date: "2024-06-22T18:15:00+09:00"
 description: "dev-weekly 2024-06-22"
-tags: ["css", "node", "javascript"]
+tags: ["css", "node", "javascript", "npm", "esm", "htmx", "react", "image"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20240629.md
+++ b/src/content/weekly/dev-weekly-20240629.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-06-29
 date: "2024-06-29T17:30:00+09:00"
 description: "dev-weekly 2024-06-29"
-tags: ["css", "javascript"]
+tags: ["css", "javascript", "typography", "typescript"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20240706.md
+++ b/src/content/weekly/dev-weekly-20240706.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-07-06
 date: "2024-07-06T18:15:00+09:00"
 description: "dev-weekly 2024-07-06"
-tags: ["css", "javascript"]
+tags: ["css", "javascript", "react", "performance", "promise", "wasm", "security"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20240713.md
+++ b/src/content/weekly/dev-weekly-20240713.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-07-13
 date: "2024-07-13T16:58:00+09:00"
 description: "dev-weekly 2024-07-13"
-tags: ["css", "node", "javascript"]
+tags: ["css", "node", "javascript", "fastify", "security", "runtime", "eslint", "react"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20240720.md
+++ b/src/content/weekly/dev-weekly-20240720.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-07-20
 date: "2024-07-20T14:47:00+09:00"
 description: "dev-weekly 2024-07-20"
-tags: ["node", "javascript"]
+tags: ["node", "javascript", "websocket", "sqlite", "playwright", "testing", "clipboard", "css"]
 ---
 
 # Node

--- a/src/content/weekly/dev-weekly-20240727.md
+++ b/src/content/weekly/dev-weekly-20240727.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-07-27
 date: "2024-07-27T15:09:00+09:00"
 description: "dev-weekly 2024-07-27"
-tags: ["node", "javascript"]
+tags: ["node", "javascript", "typescript", "astro", "rendering", "ssr", "css", "browser"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20240803.md
+++ b/src/content/weekly/dev-weekly-20240803.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-08-03
 date: "2024-08-03T14:08:00+09:00"
 description: "dev-weekly 2024-08-03"
-tags: ["css", "javascript"]
+tags: ["css", "javascript", "typescript", "font", "garbage-collection", "memory-leak", "security", "seo"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20240810.md
+++ b/src/content/weekly/dev-weekly-20240810.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-08-10
 date: "2024-08-10T16:13:00+09:00"
 description: "dev-weekly 2024-08-10"
-tags: ["css", "javascript"]
+tags: ["node", "javascript", "video", "svg", "webgpu", "ai", "llm", "astro"]
 ---
 
 # Node

--- a/src/content/weekly/dev-weekly-20240817.md
+++ b/src/content/weekly/dev-weekly-20240817.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-08-17
 date: "2024-08-17T17:30:00+09:00"
 description: "dev-weekly 2024-08-17"
-tags: ["node", "npm", "javascript"]
+tags: ["node", "npm", "javascript", "memory-leak", "dom", "performance", "angular"]
 ---
 
 # Node

--- a/src/content/weekly/dev-weekly-20240824.md
+++ b/src/content/weekly/dev-weekly-20240824.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-08-24
 date: "2024-08-24T20:45:00+09:00"
 description: "dev-weekly 2024-08-24"
-tags: ["css", "node", "javascript"]
+tags: ["css", "node", "javascript", "typescript", "regex", "sass", "vite", "bun"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20240831.md
+++ b/src/content/weekly/dev-weekly-20240831.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-08-31
 date: "2024-08-31T19:19:00+09:00"
 description: "dev-weekly 2024-08-31"
-tags: ["css", "node", "javascript"]
+tags: ["css", "node", "javascript", "typescript", "npm", "bundler", "rust", "vitest"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20240907.md
+++ b/src/content/weekly/dev-weekly-20240907.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-09-07
 date: "2024-09-07T22:53:00+09:00"
 description: "dev-weekly 2024-09-07"
-tags: ["css", "node", "javascript"]
+tags: ["css", "node", "javascript", "ssr", "docker", "performance", "devtools", "deno"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20240914.md
+++ b/src/content/weekly/dev-weekly-20240914.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-09-14
 date: "2024-09-14T22:16:00+09:00"
 description: "dev-weekly 2024-09-14"
-tags: ["css", "node", "javascript", "clipboard"]
+tags: ["css", "node", "javascript", "clipboard", "biome", "typescript", "express"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20240921.md
+++ b/src/content/weekly/dev-weekly-20240921.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-09-21
 date: "2024-09-21T13:45:00+09:00"
 description: "dev-weekly 2024-09-21"
-tags: ["css", "node", "javascript", "clipboard"]
+tags: ["css", "javascript", "react", "safari", "view-transitions", "html", "api"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20240928.md
+++ b/src/content/weekly/dev-weekly-20240928.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-09-28
 date: "2024-09-28T18:54:00+09:00"
 description: "dev-weekly 2024-09-28"
-tags: ["css", "node", "javascript", "performance"]
+tags: ["css", "deno", "performance", "devtools", "node", "masonry"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20241005.md
+++ b/src/content/weekly/dev-weekly-20241005.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-10-05
 date: "2024-10-05T10:40:00+09:00"
 description: "dev-weekly 2024-10-05"
-tags: ["javascript", "CSS", "node"]
+tags: ["css", "node", "javascript", "animation", "eslint", "http", "bundler", "typescript"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20241012.md
+++ b/src/content/weekly/dev-weekly-20241012.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-10-12
 date: "2024-10-12T17:29:00+09:00"
 description: "dev-weekly 2024-10-12"
-tags: ["javascript", "CSS", "js13kgames"]
+tags: ["css", "javascript", "firefox", "devtools", "sql", "typescript"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20241019.md
+++ b/src/content/weekly/dev-weekly-20241019.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-10-19
 date: "2024-10-19T20:45:00+09:00"
 description: "dev-weekly 2024-10-19"
-tags: ["javascript", "CSS", "node"]
+tags: ["css", "node", "javascript", "typography", "font", "unicode", "safari", "electron"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20241026.md
+++ b/src/content/weekly/dev-weekly-20241026.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-10-26
 date: "2024-10-26T13:25:00+09:00"
 description: "dev-weekly 2024-10-26"
-tags: ["javascript", "ai", "node"]
+tags: ["javascript", "ai", "svelte", "web-components", "nextjs", "react", "llm"]
 ---
 
 # Node

--- a/src/content/weekly/dev-weekly-20241102.md
+++ b/src/content/weekly/dev-weekly-20241102.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-11-02
 date: "2024-11-02T16:20:00+09:00"
 description: "dev-weekly 2024-11-02"
-tags: ["javascript", "vscode", "node", "browser", "css"]
+tags: ["css", "node", "javascript", "performance", "git", "monorepo", "safari", "accessibility"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20241109.md
+++ b/src/content/weekly/dev-weekly-20241109.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-11-09
 date: "2024-11-09T19:08:00+09:00"
 description: "dev-weekly 2024-11-09"
-tags: ["javascript", "node", "css"]
+tags: ["css", "font", "node", "wasm", "npm", "bundler", "web-audio"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20241116.md
+++ b/src/content/weekly/dev-weekly-20241116.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-11-16
 date: "2024-11-16T16:07:00+09:00"
 description: "dev-weekly 2024-11-16"
-tags: ["javascript", "node", "css"]
+tags: ["css", "node", "npm", "javascript", "browser", "react", "typescript"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20241123.md
+++ b/src/content/weekly/dev-weekly-20241123.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-11-23
 date: "2024-11-23T13:59:00+09:00"
 description: "dev-weekly 2024-11-23"
-tags: ["javascript", "node", "css"]
+tags: ["css", "anchor-positioning", "deno", "javascript", "astro", "react", "devtools", "performance"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20241130.md
+++ b/src/content/weekly/dev-weekly-20241130.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-11-30
 date: "2024-11-30T15:20:00+09:00"
 description: "dev-weekly 2024-11-30"
-tags: ["javascript", "node", "css"]
+tags: ["css", "node", "vite", "testing", "webgpu", "typescript", "browser"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20241207.md
+++ b/src/content/weekly/dev-weekly-20241207.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-12-07
 date: "2024-12-07T22:51:00+09:00"
 description: "dev-weekly 2024-12-07"
-tags: ["javascript", "node"]
+tags: ["node", "canvas", "rust", "http", "runtime", "astro", "scheduler"]
 ---
 
 # Node

--- a/src/content/weekly/dev-weekly-20241214.md
+++ b/src/content/weekly/dev-weekly-20241214.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-12-14
 date: "2024-12-14T23:19:00+09:00"
 description: "dev-weekly 2024-12-14"
-tags: ["javascript", "node", "react", "css"]
+tags: ["css", "node", "react", "compiler", "npm", "typescript", "vscode"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20241221.md
+++ b/src/content/weekly/dev-weekly-20241221.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2024-12-21
 date: "2024-12-21T19:30:00+09:00"
 description: "dev-weekly 2024-12-21"
-tags: ["node", "css"]
+tags: ["css", "graphql", "node", "performance", "github", "ai"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20250111.md
+++ b/src/content/weekly/dev-weekly-20250111.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-01-11
 date: "2025-01-11T17:10:00+09:00"
 description: "dev-weekly 2025-01-11"
-tags: ["node", "javascript", "vscode"]
+tags: ["node", "typescript", "performance", "v8", "accessibility", "vscode"]
 ---
 
 # Node

--- a/src/content/weekly/dev-weekly-20250118.md
+++ b/src/content/weekly/dev-weekly-20250118.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-01-18
 date: "2025-01-18T18:09:00+09:00"
 description: "dev-weekly 2025-01-18"
-tags: ["css", "javascript", "browser"]
+tags: ["css", "javascript", "browser", "performance", "regex", "react", "crdt"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20250125.md
+++ b/src/content/weekly/dev-weekly-20250125.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-01-25
 date: "2025-01-25T18:35:00+09:00"
 description: "dev-weekly 2025-01-25"
-tags: ["css", "javascript", "node", "bun", "browser"]
+tags: ["css", "javascript", "node", "bun", "browser", "typescript", "accessibility", "ai"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20250201.md
+++ b/src/content/weekly/dev-weekly-20250201.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-02-01
 date: "2025-02-01T13:39:00+09:00"
 description: "dev-weekly 2025-02-01"
-tags: ["javascript", "node", "wasm"]
+tags: ["javascript", "node", "wasm", "npm", "fetch", "electron", "react"]
 ---
 
 # Node

--- a/src/content/weekly/dev-weekly-20250208.md
+++ b/src/content/weekly/dev-weekly-20250208.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-02-08
 date: "2025-02-08T15:10:00+09:00"
 description: "dev-weekly 2025-02-08"
-tags: ["css", "javascript", "node", "deno"]
+tags: ["css", "javascript", "node", "deno", "wasm", "typescript", "font"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20250215.md
+++ b/src/content/weekly/dev-weekly-20250215.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-02-15
 date: "2025-02-15T15:55:00+09:00"
 description: "dev-weekly 2025-02-15"
-tags: ["javascript", "node"]
+tags: ["javascript", "node", "esm", "workers", "accessibility", "web-components"]
 ---
 
 # Node

--- a/src/content/weekly/dev-weekly-20250222.md
+++ b/src/content/weekly/dev-weekly-20250222.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-02-22
 date: "2025-02-22T21:54:00+09:00"
 description: "dev-weekly 2025-02-22"
-tags: ["javascript", "deno"]
+tags: ["javascript", "deno", "typescript", "react", "html", "opentelemetry"]
 ---
 
 # Node

--- a/src/content/weekly/dev-weekly-20250301.md
+++ b/src/content/weekly/dev-weekly-20250301.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-03-01
 date: "2025-03-01T17:20:00+09:00"
 description: "dev-weekly 2025-03-01"
-tags: ["javascript", "node", "ai", "browser"]
+tags: ["javascript", "node", "ai", "browser", "typescript", "v8", "performance", "llm"]
 ---
 
 # Node

--- a/src/content/weekly/dev-weekly-20250308.md
+++ b/src/content/weekly/dev-weekly-20250308.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-03-08
 date: "2025-03-08T12:19:00+09:00"
 description: "dev-weekly 2025-03-08"
-tags: ["javascript", "node", "ai", "browser"]
+tags: ["css", "node", "typescript", "deno", "devtools", "ai", "performance"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20250315.md
+++ b/src/content/weekly/dev-weekly-20250315.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-03-15
 date: "2025-03-15T22:32:00+09:00"
 description: "dev-weekly 2025-03-15"
-tags: ["javascript", "css", "node"]
+tags: ["css", "view-transitions", "content-visibility", "typescript", "node", "wasm", "postgres", "html"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20250322.md
+++ b/src/content/weekly/dev-weekly-20250322.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-03-22
 date: "2025-03-22T22:36:00+09:00"
 description: "dev-weekly 2025-03-22"
-tags: ["javascript", "css", "node"]
+tags: ["css", "eslint", "oxlint", "webpack", "node", "browser", "linter"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20250329.md
+++ b/src/content/weekly/dev-weekly-20250329.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-03-29
 date: "2025-03-29T15:24:00+09:00"
 description: "dev-weekly 2025-03-29"
-tags: ["javascript", "css", "node"]
+tags: ["css", "node", "v8", "performance", "security", "nextjs", "json", "accessibility"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20250412.md
+++ b/src/content/weekly/dev-weekly-20250412.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-04-12
 date: "2025-04-12T21:20:00+09:00"
 description: "dev-weekly 2025-04-12"
-tags: ["javascript", "css", "node"]
+tags: ["css", "typography", "react", "llm", "testing", "node", "deno", "electron"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20250419.md
+++ b/src/content/weekly/dev-weekly-20250419.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-04-19
 date: "2025-04-19T21:29:00+09:00"
 description: "dev-weekly 2025-04-19"
-tags: ["javascript", "css", "node"]
+tags: ["react", "javascript", "node", "css", "firefox", "temporal", "astro"]
 ---
 
 # Javascript

--- a/src/content/weekly/dev-weekly-20250426.md
+++ b/src/content/weekly/dev-weekly-20250426.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-04-26
 date: "2025-04-26T23:40:00+09:00"
 description: "dev-weekly 2025-04-26"
-tags: ["frontend", "node"]
+tags: ["node", "v8", "performance", "service-worker", "security", "react", "view-transitions"]
 ---
 
 # Node

--- a/src/content/weekly/dev-weekly-20250503.md
+++ b/src/content/weekly/dev-weekly-20250503.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-05-03
 date: "2025-05-03T17:32:00+09:00"
 description: "dev-weekly 2025-05-03"
-tags: ["javascript","frontend", "css"]
+tags: ["css", "v8", "performance", "storybook", "react", "anchor-positioning", "deno"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20250510.md
+++ b/src/content/weekly/dev-weekly-20250510.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-05-10
 date: "2025-05-10T18:25:00+09:00"
 description: "dev-weekly 2025-05-10"
-tags: ["node","javascript","frontend", "css"]
+tags: ["node", "css", "biome", "eslint", "testing", "kafka", "image"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20250517.md
+++ b/src/content/weekly/dev-weekly-20250517.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-05-17
 date: "2025-05-17T17:44:00+09:00"
 description: "dev-weekly 2025-05-17"
-tags: ["node","css", "browser"]
+tags: ["css", "container-query", "npm", "node", "security", "safari", "service-worker", "firefox"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20250524.md
+++ b/src/content/weekly/dev-weekly-20250524.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-05-24
 date: "2025-05-24T23:41:00+09:00"
 description: "dev-weekly 2025-05-24"
-tags: ["node","css", "javascript", "chrome"]
+tags: ["css", "accessibility", "typescript", "compiler", "deno", "devtools", "electron", "chrome"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20250607.md
+++ b/src/content/weekly/dev-weekly-20250607.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-06-07
 date: "2025-06-07T16:55:00+09:00"
 description: "dev-weekly 2025-06-07"
-tags: ["node", "javascript"]
+tags: ["node", "security", "npm", "react", "babel", "monorepo", "git", "browser"]
 ---
 
 # NodeJs

--- a/src/content/weekly/dev-weekly-20250614.md
+++ b/src/content/weekly/dev-weekly-20250614.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-06-14
 date: "2025-06-14T23:12:00+09:00"
 description: "dev-weekly 2025-06-14"
-tags: ["css", "node", "javascript", "react", "browser"]
+tags: ["css", "animation", "react", "eslint", "node", "safari", "webgpu", "npm"]
 ---
 
 # Javascript

--- a/src/content/weekly/dev-weekly-20250621.md
+++ b/src/content/weekly/dev-weekly-20250621.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-06-21
 date: "2025-06-21T18:37:00+09:00"
 description: "dev-weekly 2025-06-21"
-tags: ["css", "node", "javascript", "react", "browser"]
+tags: ["css", "css-grid", "html", "biome", "eslint", "react", "performance"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20250628.md
+++ b/src/content/weekly/dev-weekly-20250628.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-06-28
 date: "2025-06-28T22:02:00+09:00"
 description: "dev-weekly 2025-06-28"
-tags: ["css", "node", "javascript", "ai"]
+tags: ["css", "node", "serialization", "vite", "ai", "browser", "chrome"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20250705.md
+++ b/src/content/weekly/dev-weekly-20250705.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-07-05
 date: "2025-07-05T17:35:00+09:00"
 description: "dev-weekly 2025-07-05"
-tags: ["css", "node", "javascript"]
+tags: ["css", "svg", "node", "http", "image", "ai", "png"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20250712.md
+++ b/src/content/weekly/dev-weekly-20250712.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-07-12
 date: "2025-07-12T19:56:00+09:00"
 description: "dev-weekly 2025-07-12"
-tags: ["css", "node", "javascript"]
+tags: ["css", "popover", "json", "web-components", "bun", "typescript", "performance"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20250719.md
+++ b/src/content/weekly/dev-weekly-20250719.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-07-19
 date: "2025-07-19T19:56:00+09:00"
 description: "dev-weekly 2025-07-19"
-tags: ["css", "node", "javascript", "WASM"]
+tags: ["css", "javascript", "node", "wasm", "nextjs", "image", "performance"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20250726.md
+++ b/src/content/weekly/dev-weekly-20250726.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-07-26
 date: "2025-07-26T22:11:00+09:00"
 description: "dev-weekly 2025-07-26"
-tags: ["node", "javascript"]
+tags: ["node", "javascript", "npm", "performance", "video", "image", "css"]
 ---
 
 # Node

--- a/src/content/weekly/dev-weekly-20250802.md
+++ b/src/content/weekly/dev-weekly-20250802.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-08-02
 date: "2025-08-02T22:37:00+09:00"
 description: "dev-weekly 2025-08-02"
-tags: ["css", "node", "javascript", "w3c", "chrome", "edge"]
+tags: ["css", "node", "javascript", "chrome", "edge", "runtime", "animation", "typescript"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20250809.md
+++ b/src/content/weekly/dev-weekly-20250809.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-08-09
 date: "2025-08-09T22:28:00+09:00"
 description: "dev-weekly 2025-08-09"
-tags: ["node", "javascript"]
+tags: ["node", "javascript", "v8", "json", "vite", "performance", "typescript"]
 ---
 
 # Nodejs

--- a/src/content/weekly/dev-weekly-20250816.md
+++ b/src/content/weekly/dev-weekly-20250816.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-08-16
 date: "2025-08-16T18:15:00+09:00"
 description: "dev-weekly 2025-08-16"
-tags: ["css"]
+tags: ["css", "postcss", "documentation"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20250823.md
+++ b/src/content/weekly/dev-weekly-20250823.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-08-23
 date: "2025-08-23T23:16:00+09:00"
 description: "dev-weekly 2025-08-23"
-tags: ["css", "nodejs", "javascript"]
+tags: ["css", "node", "javascript", "typescript", "wasm", "python", "bun"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20250830.md
+++ b/src/content/weekly/dev-weekly-20250830.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-08-30
 date: "2025-08-30T21:12:00+09:00"
 description: "dev-weekly 2025-08-30"
-tags: ["css", "javascript"]
+tags: ["css", "javascript", "eslint", "bundler", "pwa", "performance"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20250906.md
+++ b/src/content/weekly/dev-weekly-20250906.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-09-06
 date: "2025-09-06T21:30:00+09:00"
 description: "dev-weekly 2025-09-06"
-tags: ["javascript", "browser", "chrome"]
+tags: ["javascript", "browser", "chrome", "video", "angular", "electron"]
 ---
 
 # Javascript

--- a/src/content/weekly/dev-weekly-20250913.md
+++ b/src/content/weekly/dev-weekly-20250913.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-09-13
 date: "2025-09-13T20:13:00+09:00"
 description: "dev-weekly 2025-09-13"
-tags: ["css", "nodejs", "javascript", "bun", "deno"]
+tags: ["css", "animation", "node", "bun", "npm", "security", "javascript", "runtime"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20250920.md
+++ b/src/content/weekly/dev-weekly-20250920.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-09-20
 date: "2025-09-20T18:55:00+09:00"
 description: "dev-weekly 2025-09-20"
-tags: ["javascript", "npm", "wasm"]
+tags: ["npm", "security", "wasm", "svg", "javascript", "safari"]
 ---
 
 # Nodejs

--- a/src/content/weekly/dev-weekly-20250927.md
+++ b/src/content/weekly/dev-weekly-20250927.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-09-27
 date: "2025-09-27T23:16:00+09:00"
 description: "dev-weekly 2025-09-27"
-tags: ["javascript", "css", "browser", "ai"]
+tags: ["css", "animation", "image", "browser", "chrome", "ai", "devtools"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20251004.md
+++ b/src/content/weekly/dev-weekly-20251004.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-10-04
 date: "2025-10-04T23:16:00+09:00"
 description: "dev-weekly 2025-10-04"
-tags: ["javascript", "css", "nodejs", "workers", "npx", "http"]
+tags: ["css", "animation", "node", "workers", "npx", "react", "http", "accessibility"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20251011.md
+++ b/src/content/weekly/dev-weekly-20251011.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-10-11
 date: "2025-10-11T22:19:00+09:00"
 description: "dev-weekly 2025-10-11"
-tags: ["javascript", "css", "nodejs", "bun"]
+tags: ["css", "node", "bun", "eslint", "react", "view-transitions", "accessibility", "ai"]
 ---
 # CSS
 

--- a/src/content/weekly/dev-weekly-20251018.md
+++ b/src/content/weekly/dev-weekly-20251018.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-10-18
 date: "2025-10-18T22:21:00+09:00"
 description: "dev-weekly 2025-10-18"
-tags: ["javascript", "nodejs"]
+tags: ["node", "python", "web-components", "svg", "javascript", "vite"]
 ---
 
 # Nodejs

--- a/src/content/weekly/dev-weekly-20251025.md
+++ b/src/content/weekly/dev-weekly-20251025.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-10-25
 date: "2025-10-25T18:20:00+09:00"
 description: "dev-weekly 2025-10-25"
-tags: ["javascript", "nodejs", "vitest", "biome"]
+tags: ["node", "vitest", "biome", "javascript", "json", "accessibility", "browser"]
 ---
 
 # NodeJS

--- a/src/content/weekly/dev-weekly-20251101.md
+++ b/src/content/weekly/dev-weekly-20251101.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-11-01
 date: "2025-11-01T20:25:00+09:00"
 description: "dev-weekly 2025-11-01"
-tags: ["javascript", "nodejs", "css"]
+tags: ["css", "performance", "node", "deno", "typescript", "regex", "javascript"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20251108.md
+++ b/src/content/weekly/dev-weekly-20251108.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-11-08
 date: "2025-11-08T20:25:00+09:00"
 description: "dev-weekly 2025-11-08"
-tags: ["javascript", "bun", "css", "video", "animation"]
+tags: ["css", "field-sizing", "source-map", "bun", "view-transitions", "animation", "devtools", "electron"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20251115.md
+++ b/src/content/weekly/dev-weekly-20251115.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-11-15
 date: "2025-11-15T20:25:00+09:00"
 description: "dev-weekly 2025-11-15"
-tags: ["javascript"]
+tags: ["javascript", "accessibility", "v8", "electron", "tauri", "wasm", "esbuild", "pnpm"]
 ---
 
 # Javascript

--- a/src/content/weekly/dev-weekly-20251122.md
+++ b/src/content/weekly/dev-weekly-20251122.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-11-22
 date: "2025-11-22T19:37:00+09:00"
 description: "dev-weekly 2025-11-22"
-tags: ["css", "nodejs"]
+tags: ["svg", "npm", "security", "github", "font", "image", "angular", "vitest"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20251129.md
+++ b/src/content/weekly/dev-weekly-20251129.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-11-29
 date: "2025-11-29T18:15:00+09:00"
 description: "dev-weekly 2025-11-29"
-tags: ["css", "nodejs", "javascript"]
+tags: ["css", "animation", "node", "typescript", "wasm", "webgpu", "accessibility", "playwright"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20251206.md
+++ b/src/content/weekly/dev-weekly-20251206.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-12-06
 date: "2025-12-06T23:08:00+09:00"
 description: "dev-weekly 2025-12-06"
-tags: ["css", "nodejs", "javascript", "bun"]
+tags: ["css", "anchor-positioning", "node", "nextjs", "typescript", "bun", "vite", "performance"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20251213.md
+++ b/src/content/weekly/dev-weekly-20251213.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-12-13
 date: "2025-12-13T20:11:00+09:00"
 description: "dev-weekly 2025-12-13"
-tags: ["nodejs", "javascript"]
+tags: ["node", "performance", "typescript", "accessibility", "source-map", "bundler", "video", "deno"]
 ---
 
 # Nodejs

--- a/src/content/weekly/dev-weekly-20251220.md
+++ b/src/content/weekly/dev-weekly-20251220.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2025-12-20
 date: "2025-12-20T17:52:00+09:00"
 description: "dev-weekly 2025-12-20"
-tags: ["javascript"]
+tags: ["javascript", "bundler", "performance", "react", "nextjs", "bun"]
 ---
 
 # Javascript

--- a/src/content/weekly/dev-weekly-20260110.md
+++ b/src/content/weekly/dev-weekly-20260110.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2026-01-10
 date: "2026-01-10T19:57:00+09:00"
 description: "dev-weekly 2026-01-10"
-tags: ["javascript", "nodejs", "bun"]
+tags: ["javascript", "bun", "runtime", "deno", "node", "esm", "html"]
 ---
 
 # Javascript

--- a/src/content/weekly/dev-weekly-20260117.md
+++ b/src/content/weekly/dev-weekly-20260117.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2026-01-17
 date: "2026-01-17T18:02:00+09:00"
 description: "dev-weekly 2026-01-17"
-tags: ["javascript", "nodejs"]
+tags: ["javascript", "node", "css", "react", "chrome", "performance", "jpeg", "browser"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20260124.md
+++ b/src/content/weekly/dev-weekly-20260124.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2026-01-24
 date: "2026-01-24T20:58:00+09:00"
 description: "dev-weekly 2026-01-24"
-tags: ["javascript", "nodejs"]
+tags: ["javascript", "node", "jquery", "ai", "astro", "electron", "prettier", "image"]
 ---
 
 # Nodejs

--- a/src/content/weekly/dev-weekly-20260131.md
+++ b/src/content/weekly/dev-weekly-20260131.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2026-01-31
 date: "2026-01-31T20:35:00+09:00"
 description: "dev-weekly 2026-01-31"
-tags: ["javascript", "nodejs", "css"]
+tags: ["javascript", "node", "css", "typescript", "pdf", "bundler", "performance", "cms"]
 ---
 
 # Nodejs

--- a/src/content/weekly/dev-weekly-20260207.md
+++ b/src/content/weekly/dev-weekly-20260207.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2026-02-07
 date: "2026-02-07T22:46:00+09:00"
 description: "dev-weekly 2026-02-07"
-tags: ["javascript", "nodejs", "css"]
+tags: ["javascript", "node", "css", "typescript", "chrome", "ai", "devtools", "video"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20260214.md
+++ b/src/content/weekly/dev-weekly-20260214.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2026-02-14
 date: "2026-02-14T20:42:00+09:00"
 description: "dev-weekly 2026-02-14"
-tags: ["javascript", "nodejs", "css"]
+tags: ["javascript", "node", "css", "webpack", "accessibility", "typescript", "eslint", "ai"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20260221.md
+++ b/src/content/weekly/dev-weekly-20260221.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2026-02-21
 date: "2026-02-21T17:36:00+09:00"
 description: "dev-weekly 2026-02-21"
-tags: ["javascript", "nodejs", "css"]
+tags: ["javascript", "node", "css", "v8", "performance", "electron", "bun", "biome"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20260228.md
+++ b/src/content/weekly/dev-weekly-20260228.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2026-02-28
 date: "2026-02-28T21:58:00+09:00"
 description: "dev-weekly 2026-02-28"
-tags: ["javascript", "nodejs", "css"]
+tags: ["javascript", "node", "css", "typescript", "security", "web-components", "pwa", "npm"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20260307.md
+++ b/src/content/weekly/dev-weekly-20260307.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2026-03-07
 date: "2026-03-07T21:04:00+09:00"
 description: "dev-weekly 2026-03-07"
-tags: ["javascript", "nodejs"]
+tags: ["javascript", "bun", "wasm", "react", "security", "accessibility", "chrome", "drm"]
 ---
 
 # Javascript

--- a/src/content/weekly/dev-weekly-20260314.md
+++ b/src/content/weekly/dev-weekly-20260314.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2026-03-14
 date: "2026-03-14T21:54:00+09:00"
 description: "dev-weekly 2026-03-14"
-tags: ["javascript", "nodejs"]
+tags: ["javascript", "node", "vite", "rollup", "video", "performance", "security", "typescript"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20260321.md
+++ b/src/content/weekly/dev-weekly-20260321.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2026-03-21
 date: "2026-03-21T22:47:00+09:00"
 description: "dev-weekly 2026-03-21"
-tags: ["javascript", "nodejs", "jpeg"]
+tags: ["javascript", "node", "source-map", "typescript", "jpeg", "image", "performance", "browser"]
 ---
 
 # Nodejs

--- a/src/content/weekly/dev-weekly-20260328.md
+++ b/src/content/weekly/dev-weekly-20260328.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2026-03-28
 date: "2026-03-28T22:24:00+09:00"
 description: "dev-weekly 2026-03-28"
-tags: ["javascript", "nodejs", "css"]
+tags: ["javascript", "node", "css", "wasm", "rust", "typescript", "performance", "video"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20260404.md
+++ b/src/content/weekly/dev-weekly-20260404.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2026-04-04
 date: "2026-04-04T22:31:00+09:00"
 description: "dev-weekly 2026-04-04"
-tags: ["javascript"]
+tags: ["javascript", "npm", "security", "react", "image", "signal", "wasm"]
 ---
 
 # Javascript

--- a/src/content/weekly/dev-weekly-20260411.md
+++ b/src/content/weekly/dev-weekly-20260411.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2026-04-11
 date: "2026-04-11T21:24:00+09:00"
 description: "dev-weekly 2026-04-11"
-tags: ["javascript", "nodejs"]
+tags: ["javascript", "node", "compiler", "security", "wasm", "performance", "eslint"]
 ---
 
 # Javascript

--- a/src/content/weekly/dev-weekly-20260418.md
+++ b/src/content/weekly/dev-weekly-20260418.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2026-04-18
 date: "2026-04-18T20:20:00+09:00"
 description: "dev-weekly 2026-04-18"
-tags: ["javascript", "nodejs", "css", "AEO", "v8"]
+tags: ["javascript", "node", "css", "v8", "animation", "web-components", "typescript", "git"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20260425.md
+++ b/src/content/weekly/dev-weekly-20260425.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2026-04-25
 date: "2026-04-25T23:04:00+09:00"
 description: "dev-weekly 2026-04-25"
-tags: ["javascript", "nodejs", "css"]
+tags: ["javascript", "node", "css", "container-query", "typography", "accessibility", "video", "typescript"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20260502.md
+++ b/src/content/weekly/dev-weekly-20260502.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2026-05-02
 date: "2026-05-02T15:25:00+09:00"
 description: "dev-weekly 2026-05-02"
-tags: ["javascript", "css"]
+tags: ["javascript", "css", "animation", "node", "image", "font", "go"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20260509.md
+++ b/src/content/weekly/dev-weekly-20260509.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2026-05-09
 date: "2026-05-09T17:54:00+09:00"
 description: "dev-weekly 2026-05-09"
-tags: ["javascript", "nodejs", "css"]
+tags: ["javascript", "node", "remix", "rolldown", "bundler", "security", "browser", "astro"]
 ---
 
 # Javascript

--- a/src/content/weekly/dev-weekly-20260516.md
+++ b/src/content/weekly/dev-weekly-20260516.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2026-05-16
 date: "2026-05-16T21:31:00+09:00"
 description: "dev-weekly 2026-05-16"
-tags: ["javascript", "nodejs"]
+tags: ["javascript", "node", "compiler", "v8", "pwa", "devtools", "http", "browser"]
 ---
 
 # Javascript

--- a/src/content/weekly/dev-weekly-20260523.md
+++ b/src/content/weekly/dev-weekly-20260523.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2026-05-23
 date: "2026-05-23T21:31:00.000Z"
 description: "dev-weekly 2026-05-23"
-tags: ["css", "javascript", "nodejs"]
+tags: ["css", "javascript", "node", "i18n", "accessibility", "web-components", "npm", "fetch"]
 ---
 
 # CSS

--- a/src/content/weekly/dev-weekly-20260530.md
+++ b/src/content/weekly/dev-weekly-20260530.md
@@ -2,7 +2,7 @@
 title: dev-weekly 2026-05-30
 date: "2026-05-30T22:47:00.000Z"
 description: "dev-weekly 2026-05-30"
-tags: ["css", "javascript"]
+tags: ["css", "javascript", "animation", "font", "json", "wasm", "deno"]
 ---
 
 # CSS

--- a/src/content/weekly/weekly-20200208.md
+++ b/src/content/weekly/weekly-20200208.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-02-08
 date: "2020-02-08T08:30:00+09:00"
 description: "javascript weekly 2020-02-08"
-tags: ["javascript"]
+tags: ["javascript", "angular", "electron", "wasm", "testing", "accessibility", "i18n"]
 ---
 
 

--- a/src/content/weekly/weekly-20200215.md
+++ b/src/content/weekly/weekly-20200215.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-02-15
 date: "2020-02-15T08:30:00+09:00"
 description: "javascript weekly 2020-02-15"
-tags: ["javascript"]
+tags: ["javascript", "typescript", "webgl", "html", "docker"]
 ---
 
 

--- a/src/content/weekly/weekly-20200222.md
+++ b/src/content/weekly/weekly-20200222.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-02-22
 date: "2020-02-22T08:30:00+09:00"
 description: "javascript weekly 2020-02-22"
-tags: ["javascript"]
+tags: ["javascript", "typescript", "react", "redux", "git", "node", "performance", "devtools"]
 ---
 
 # Fixing Memory Leaks in Web Applications

--- a/src/content/weekly/weekly-20200229.md
+++ b/src/content/weekly/weekly-20200229.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-02-29
 date: "2020-02-29T08:30:00+09:00"
 description: "javascript weekly 2020-02-29"
-tags: ["javascript"]
+tags: ["javascript", "v8", "i18n", "react", "node", "puppeteer"]
 ---
 
 # V8 v8.1's Intl.DisplayNames

--- a/src/content/weekly/weekly-20200307.md
+++ b/src/content/weekly/weekly-20200307.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-03-07
 date: "2020-03-07T08:30:00+09:00"
 description: "javascript weekly 2020-03-07"
-tags: ["javascript"]
+tags: ["javascript", "rollup", "bundler", "node", "esm", "error-handling"]
 ---
 
 # Rollup 2.0 Released: The ES Module Bundler

--- a/src/content/weekly/weekly-20200314.md
+++ b/src/content/weekly/weekly-20200314.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-03-14
 date: "2020-03-14T08:30:00+09:00"
 description: "javascript weekly 2020-03-14. 재미난 글이 적어서 VSCode UPdate를 끼워넣음"
-tags: ["javascript"]
+tags: ["javascript", "vscode", "abort-controller", "performance", "browser"]
 ---
 
 # VSCode 1.43

--- a/src/content/weekly/weekly-20200321.md
+++ b/src/content/weekly/weekly-20200321.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-03-21
 date: "2020-03-21T08:30:00+09:00"
 description: "javascript weekly 2020-03-21"
-tags: ["javascript"]
+tags: ["javascript", "chart", "npm", "github"]
 ---
 
 # uPlot

--- a/src/content/weekly/weekly-20200328.md
+++ b/src/content/weekly/weekly-20200328.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-03-28
 date: "2020-03-28T08:30:00+09:00"
 description: "javascript weekly 2020-03-28"
-tags: ["javascript"]
+tags: ["javascript", "core-js", "open-source", "performance", "git"]
 ---
 
 # What Happens When the Maintainer of a Major JS Library Goes to Jail?

--- a/src/content/weekly/weekly-20200404.md
+++ b/src/content/weekly/weekly-20200404.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-04-04
 date: "2020-04-04T08:30:00+09:00"
 description: "javascript weekly 2020-04-04"
-tags: ["javascript"]
+tags: ["javascript", "typescript", "es2020", "v8", "json", "offscreen-canvas", "kubernetes", "node"]
 ---
 
 #

--- a/src/content/weekly/weekly-20200411.md
+++ b/src/content/weekly/weekly-20200411.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-04-11
 date: "2020-04-11T08:00:00+09:00"
 description: "javascript weekly 2020-04-11"
-tags: ["javascript"]
+tags: ["javascript", "github", "commonjs", "esm", "webpack", "babel"]
 ---
 
 #

--- a/src/content/weekly/weekly-20200502.md
+++ b/src/content/weekly/weekly-20200502.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-05-02
 date: "2020-05-02T09:30:00+09:00"
 description: "javascript weekly 2020-05-02"
-tags: ["javascript"]
+tags: ["javascript", "typescript", "react", "webgpu", "firefox", "web-worker", "mdx"]
 ---
 
 # The Power of Your GPU—Now Coming to Firefox Nightly

--- a/src/content/weekly/weekly-20200509.md
+++ b/src/content/weekly/weekly-20200509.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-05-09
 date: "2020-05-09T09:30:00+09:00"
 description: "javascript weekly 2020-05-09"
-tags: ["javascript"]
+tags: ["javascript", "jest", "testing", "deno", "vscode", "web-worker", "electron"]
 ---
 
 # Jest 26 Released: The Popular Testing Framework

--- a/src/content/weekly/weekly-20200516.md
+++ b/src/content/weekly/weekly-20200516.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-05-16
 date: "2020-05-16T09:00:00+09:00"
 description: "javascript weekly 2020-05-16"
-tags: ["javascript"]
+tags: ["javascript", "playwright", "testing", "react", "recoil", "wasm", "eslint", "animation"]
 ---
 
 # Playwright 1.0: Fast and Reliable Cross-Browser Testing

--- a/src/content/weekly/weekly-20200523.md
+++ b/src/content/weekly/weekly-20200523.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-05-23
 date: "2020-05-23T09:00:00+09:00"
 description: "javascript weekly 2020-05-23"
-tags: ["javascript"]
+tags: ["javascript", "webgl", "react", "react-native"]
 ---
 
 # A Complete Walkthrough to Using WebGL 

--- a/src/content/weekly/weekly-20200530.md
+++ b/src/content/weekly/weekly-20200530.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-05-30
 date: "2020-05-30T09:00:00+09:00"
 description: "javascript weekly 2020-05-30"
-tags: ["javascript"]
+tags: ["javascript", "snowpack", "bundler", "wasm", "electron", "performance", "gatsby"]
 ---
 
 # Snowpack 2.0: A Build System for the Modern Web

--- a/src/content/weekly/weekly-20200606.md
+++ b/src/content/weekly/weekly-20200606.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-06-06
 date: "2020-06-06T09:30:00+09:00"
 description: "javascript weekly 2020-06-06"
-tags: ["javascript"]
+tags: ["javascript", "babel", "deno", "angular", "service-worker", "pwa"]
 ---
 
 # Babel 7.10.0 Released

--- a/src/content/weekly/weekly-20200613.md
+++ b/src/content/weekly/weekly-20200613.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-06-13
 date: "2020-06-13T09:30:00+09:00"
 description: "javascript weekly 2020-06-13"
-tags: ["javascript"]
+tags: ["javascript", "prisma", "node", "express", "rate-limiting", "electron", "vscode"]
 ---
 
 # An ECMAScript Proposal: Logical Assignment Operators

--- a/src/content/weekly/weekly-20200620.md
+++ b/src/content/weekly/weekly-20200620.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-06-20
 date: "2020-06-20T09:30:00+09:00"
 description: "javascript weekly 2020-06-20"
-tags: ["javascript"]
+tags: ["javascript", "puppeteer", "testing", "chrome", "slider", "bootstrap", "compiler"]
 ---
 
 # keen-slider: An Agnostic Touch Slider

--- a/src/content/weekly/weekly-20200627.md
+++ b/src/content/weekly/weekly-20200627.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-06-27
 date: "2020-06-27T09:00:00+09:00"
 description: "javascript weekly 2020-06-27"
-tags: ["javascript"]
+tags: ["javascript", "typescript", "optional-chaining", "react-query", "chrome", "devtools", "graphql"]
 ---
 
 # Lessons Learned Refactoring Optional Chaining Into a Large Codebase

--- a/src/content/weekly/weekly-20200704.md
+++ b/src/content/weekly/weekly-20200704.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-07-04
 date: "2020-07-04T08:30:00+09:00"
 description: "javascript weekly 2020-07-04"
-tags: ["javascript"]
+tags: ["javascript", "typescript", "v8", "node", "wasm", "web-components", "svelte"]
 ---
 
 # Announcing TypeScript 4.0 Beta

--- a/src/content/weekly/weekly-20200711.md
+++ b/src/content/weekly/weekly-20200711.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-07-11
 date: "2020-07-11T09:00:00+09:00"
 description: "javascript weekly 2020-07-11"
-tags: ["javascript"]
+tags: ["javascript", "performance", "svelte", "compiler", "rust", "wasm", "eslint", "npm"]
 ---
 
 # Perf Track: Tracking the Performance of Sites Using Popular JS Frameworks

--- a/src/content/weekly/weekly-20200718.md
+++ b/src/content/weekly/weekly-20200718.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-07-18
 date: "2020-07-18T09:30:00+09:00"
 description: "javascript weekly 2020-07-18"
-tags: ["javascript"]
+tags: ["javascript", "regex", "graphql", "react", "uuid"]
 ---
 
 # Super Expressive: Build Regexes in (Almost) Natural Language

--- a/src/content/weekly/weekly-20200725.md
+++ b/src/content/weekly/weekly-20200725.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-07-25
 date: "2020-07-25T10:30:00+09:00"
 description: "javascript weekly 2020-07-25"
-tags: ["javascript"]
+tags: ["javascript", "typescript", "svelte", "v8", "wasm", "node", "i18n", "react"]
 ---
 
 # Several New Features Promoted to Stage 4 at TC39

--- a/src/content/weekly/weekly-20200801.md
+++ b/src/content/weekly/weekly-20200801.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-08-01
 date: "2020-08-01T09:30:00+09:00"
 description: "javascript weekly 2020-08-01"
-tags: ["javascript"]
+tags: ["javascript", "react", "vue", "nextjs", "performance", "webpack"]
 ---
 
 # I created the exact same app in React and Vue. Here are the differences. [2020 Edition]

--- a/src/content/weekly/weekly-20200808.md
+++ b/src/content/weekly/weekly-20200808.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-08-08
 date: "2020-08-08T09:30:00+09:00"
 description: "javascript weekly 2020-08-08"
-tags: ["javascript"]
+tags: ["javascript", "typescript", "angular", "regex", "unicode"]
 ---
 
 # 1Keys: How I Made a Piano in Only 1KB of JavaScript

--- a/src/content/weekly/weekly-20200815.md
+++ b/src/content/weekly/weekly-20200815.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-08-15
 date: "2020-08-15T08:30:00+09:00"
 description: "javascript weekly 2020-08-15"
-tags: ["javascript"]
+tags: ["javascript", "react", "node", "rust", "wasm", "deno", "service-worker", "storybook"]
 ---
 
 # Rome: Unifying The Frontend Development Toolchain

--- a/src/content/weekly/weekly-20200822.md
+++ b/src/content/weekly/weekly-20200822.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-08-22
 date: "2020-08-22T08:30:00+09:00"
 description: "javascript weekly 2020-08-22"
-tags: ["javascript"]
+tags: ["javascript", "typescript", "npm", "testing", "svelte", "proxy"]
 ---
 
 # TypeScript 4.0 Released

--- a/src/content/weekly/weekly-20200829.md
+++ b/src/content/weekly/weekly-20200829.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-08-29
 date: "2020-08-29T09:30:00+09:00"
 description: "javascript weekly 2020-08-29"
-tags: ["javascript"]
+tags: ["javascript", "typography", "electron", "python", "devtools", "react"]
 ---
 
 # ztext.js: A 3D Typography Effect for the Web

--- a/src/content/weekly/weekly-20200905.md
+++ b/src/content/weekly/weekly-20200905.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-09-05
 date: "2020-09-05T09:30:00+09:00"
 description: "javascript weekly 2020-09-05"
-tags: ["javascript"]
+tags: ["javascript", "requestanimationframe", "browser", "svelte", "eslint", "webpack", "web-components", "ngrx"]
 ---
 
 # Mastering the Hard Parts of JavaScript

--- a/src/content/weekly/weekly-20200912.md
+++ b/src/content/weekly/weekly-20200912.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-09-12
 date: "2020-09-12T09:30:00+09:00"
 description: "javascript weekly 2020-09-12"
-tags: ["javascript"]
+tags: ["javascript", "playwright", "testing", "devtools", "cloudflare", "workers", "react", "vscode"]
 ---
 
 # Playwright 1.4: Fast and Reliable Cross-Browser Testing

--- a/src/content/weekly/weekly-20200919.md
+++ b/src/content/weekly/weekly-20200919.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-09-19
 date: "2020-09-19T09:00:00+09:00"
 description: "javascript weekly 2020-09-19"
-tags: ["javascript"]
+tags: ["javascript", "vue", "deno", "node", "security", "jit", "http2", "testing"]
 ---
 
 # Vue 3.0 'One Piece' Released

--- a/src/content/weekly/weekly-20200926.md
+++ b/src/content/weekly/weekly-20200926.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-09-26
 date: "2020-09-26T08:30:00+09:00"
 description: "javascript weekly 2020-09-26"
-tags: ["javascript"]
+tags: ["javascript", "web-components", "v8", "deno", "typescript", "react", "wasm", "database"]
 ---
 
 # Vime: A Customizable Media Player Built with Web Components

--- a/src/content/weekly/weekly-20201003.md
+++ b/src/content/weekly/weekly-20201003.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-10-03
 date: "2020-10-03T09:30:00+09:00"
 description: "javascript weekly 2020-10-03"
-tags: ["javascript"]
+tags: ["javascript", "esbuild", "bundler", "mobx", "npm", "react", "svelte", "memory-leak"]
 ---
 
 # esbuild: A Super Fast JavaScript Bundler and Minifier

--- a/src/content/weekly/weekly-20201010.md
+++ b/src/content/weekly/weekly-20201010.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-10-10
 date: "2020-10-10T08:00:00+09:00"
 description: "javascript weekly 2020-10-10"
-tags: ["javascript"]
+tags: ["javascript", "rust", "eslint", "volta", "wasm", "go", "file-system-access", "vscode"]
 ---
 
 # RSLint: A Super Fast JS Linter Written in Rust

--- a/src/content/weekly/weekly-20201017.md
+++ b/src/content/weekly/weekly-20201017.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-10-17
 date: "2020-10-17T09:30:00+09:00"
 description: "javascript weekly 2020-10-17"
-tags: ["javascript"]
+tags: ["javascript", "webpack", "npm", "babel", "typescript", "node", "clipboard", "wasm"]
 ---
 
 # webpack 5 Released

--- a/src/content/weekly/weekly-20201024.md
+++ b/src/content/weekly/weekly-20201024.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-10-24
 date: "2020-10-24T10:00:00+09:00"
 description: "javascript weekly 2020-10-24"
-tags: ["javascript"]
+tags: ["javascript", "react", "node", "v8", "clipboard", "tensorflow", "fingerprint", "skypack"]
 ---
 
 # React 17.0 Released

--- a/src/content/weekly/weekly-20201031.md
+++ b/src/content/weekly/weekly-20201031.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-10-31
 date: "2020-10-31T10:00:00+09:00"
 description: "javascript weekly 2020-10-31"
-tags: ["javascript"]
+tags: ["javascript", "react", "node", "deno", "nextjs", "wasm", "memory-management"]
 ---
 
 # Create React App 4.0 Released

--- a/src/content/weekly/weekly-20201107.md
+++ b/src/content/weekly/weekly-20201107.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-11-07
 date: "2020-11-07T09:00:00+09:00"
 description: "javascript weekly 2020-11-07"
-tags: ["javascript"]
+tags: ["javascript", "svelte", "redux", "security", "wasm", "websocket", "node", "json"]
 ---
 
 # What's the Deal with Svelte and SvelteKit?

--- a/src/content/weekly/weekly-20201114.md
+++ b/src/content/weekly/weekly-20201114.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-11-14
 date: "2020-11-14T09:10:00+09:00"
 description: "javascript weekly 2020-11-14"
-tags: ["javascript"]
+tags: ["javascript", "typescript", "angular", "v8", "webpack", "database", "websocket"]
 ---
 
 ## 10 Insights From Adopting TypeScript At Scale

--- a/src/content/weekly/weekly-20201121.md
+++ b/src/content/weekly/weekly-20201121.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-11-21
 date: "2020-11-21T09:30:00+09:00"
 description: "javascript weekly 2020-11-21"
-tags: ["javascript"]
+tags: ["javascript", "typescript", "wasm", "prettier", "electron", "react", "security"]
 ---
 
 ## TypeScript 4.1 Released

--- a/src/content/weekly/weekly-20201128.md
+++ b/src/content/weekly/weekly-20201128.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-11-28
 date: "2020-11-28T10:00:00+09:00"
 description: "javascript weekly 2020-11-28"
-tags: ["javascript"]
+tags: ["javascript", "typescript", "wasm", "performance", "browser", "ml"]
 ---
 
 ## Flash Animations Live Forever at the Internet Archive

--- a/src/content/weekly/weekly-20201205.md
+++ b/src/content/weekly/weekly-20201205.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-12-05
 date: "2020-12-05T10:00:00+09:00"
 description: "javascript weekly 2020-12-05"
-tags: ["javascript"]
+tags: ["javascript", "bundler", "esbuild", "chrome", "yarn", "testing", "json", "image"]
 ---
 
 ## WMR: A Tiny All-in-One Development Tool for Modern Web Apps

--- a/src/content/weekly/weekly-20201212.md
+++ b/src/content/weekly/weekly-20201212.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-12-12
 date: "2020-12-12T09:00:00+09:00"
 description: "javascript weekly 2020-12-12"
-tags: ["javascript"]
+tags: ["javascript", "performance", "deno", "electron", "react", "webpack", "ssr"]
 ---
 
 ## The 'Import on Interaction' Pattern

--- a/src/content/weekly/weekly-20201219.md
+++ b/src/content/weekly/weekly-20201219.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2020-12-19
 date: "2020-12-19T10:00:00+09:00"
 description: "javascript weekly 2020-12-19"
-tags: ["javascript"]
+tags: ["javascript", "node", "typescript", "database", "css", "graphql", "testing"]
 ---
 
 ## A Growing Collection of 100+ Node.js Best Practices

--- a/src/content/weekly/weekly-20210109.md
+++ b/src/content/weekly/weekly-20210109.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2021-01-09
 date: "2021-01-09T09:30:00+09:00"
 description: "javascript weekly 2021-01-09, 2020 rank"
-tags: ["javascript"]
+tags: ["javascript", "memory-leak", "performance", "css", "animation"]
 ---
 
 # most clicked links of 2020

--- a/src/content/weekly/weekly-20210116.md
+++ b/src/content/weekly/weekly-20210116.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2021-01-16
 date: "2021-01-16T08:40:00+09:00"
 description: "javascript weekly 2021-01-16"
-tags: ["javascript"]
+tags: ["javascript", "typescript", "node", "esm", "snowpack", "promise", "docker", "clipboard"]
 ---
 
 ## The State of JS 2020 Survey Results

--- a/src/content/weekly/weekly-20210123.md
+++ b/src/content/weekly/weekly-20210123.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2021-01-23
 date: "2021-01-23T09:30:00+09:00"
 description: "javascript weekly 2021-01-23"
-tags: ["javascript"]
+tags: ["javascript", "esm", "performance", "svg", "accessibility", "browser-extension", "clipboard"]
 ---
 
 ## The JavaScript 'Rising Stars' of 2020

--- a/src/content/weekly/weekly-20210130.md
+++ b/src/content/weekly/weekly-20210130.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2021-01-30
 date: "2021-01-30T09:40:00+09:00"
 description: "javascript weekly 2021-01-30"
-tags: ["javascript"]
+tags: ["javascript", "testing", "playwright", "cypress", "webrtc", "esm", "source-map", "rxjs"]
 ---
 
 ## TOAST UI Chart 4.0 Released

--- a/src/content/weekly/weekly-20210206.md
+++ b/src/content/weekly/weekly-20210206.md
@@ -2,7 +2,7 @@
 title: javascript weekly 2021-02-06
 date: "2021-02-06T09:40:00+09:00"
 description: "javascript weekly 2021-02-06"
-tags: ["javascript"]
+tags: ["javascript", "performance", "npm", "v8", "go", "vue", "graalvm"]
 ---
 
 ## Making GitHub’s New Homepage Fast and Performant


### PR DESCRIPTION
- 325개 글(blog/weekly/archive)의 태그를 본문이 실제 다루는 주제로 보강 (글당 평균 2.8 → 7.4개, 고유 태그 47 → 224개)
- 표기 정규화: 소문자/kebab-case/단수형, 동의어 병합(node, javascript 등), 일반·모호 태그 제거
- scripts/normalize-tags.mjs: 재사용 가능한 태그 정규화 스크립트(멱등)
- CLAUDE.md: 태그 컨벤션과 새 글 태깅 절차 문서화