### PR TITLE
feat: 테마 토글 (시스템/라이트/다크)

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -14,6 +14,18 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
 ---
 
+<!-- 테마: 페인트 전에 저장된 선택을 적용해 FOUC 방지 -->
+<script is:inline>
+  (function () {
+    try {
+      var t = localStorage.getItem('theme');
+      if (t === 'light' || t === 'dark') {
+        document.documentElement.dataset.theme = t;
+      }
+    } catch (e) {}
+  })();
+</script>
+
 <!-- Global Metadata -->
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -23,7 +23,7 @@ import { SITE_TITLE } from '../consts';
     <div class="search">
       <Search />
     </div>
-    <button id="theme-toggle" class="theme-toggle" type="button" aria-label="테마 전환">
+    <button id="theme-toggle" class="theme-toggle" type="button" title="테마 전환" aria-label="테마 전환">
       <svg class="i-system" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <rect x="2" y="3" width="20" height="14" rx="2"></rect>
         <path d="M8 21h8M12 17v4"></path>
@@ -72,7 +72,9 @@ import { SITE_TITLE } from '../consts';
   const apply = (m: string) => {
     if (m === 'system') delete html.dataset.theme;
     else html.dataset.theme = m;
-    btn?.setAttribute('aria-label', `테마: ${labels[m]} (클릭해 전환)`);
+    const text = `테마 전환 · 현재: ${labels[m]}`;
+    btn?.setAttribute('aria-label', text);
+    btn?.setAttribute('title', text);
   };
 
   apply(get());

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -23,6 +23,19 @@ import { SITE_TITLE } from '../consts';
     <div class="search">
       <Search />
     </div>
+    <button id="theme-toggle" class="theme-toggle" type="button" aria-label="테마 전환">
+      <svg class="i-system" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <rect x="2" y="3" width="20" height="14" rx="2"></rect>
+        <path d="M8 21h8M12 17v4"></path>
+      </svg>
+      <svg class="i-light" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <circle cx="12" cy="12" r="4"></circle>
+        <path d="M12 2v2M12 20v2M2 12h2M20 12h2M5 5l1.5 1.5M17.5 17.5 19 19M19 5l-1.5 1.5M6.5 17.5 5 19"></path>
+      </svg>
+      <svg class="i-dark" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M21 12.8A8 8 0 1 1 11.2 3 6 6 0 0 0 21 12.8z"></path>
+      </svg>
+    </button>
     <div class="social-links">
       <a href="https://github.com/deadintegral/stupidk-blog-astro" target="_blank" aria-label="GitHub">
         <span class="sr-only">Go to GitHub repo</span>
@@ -36,6 +49,40 @@ import { SITE_TITLE } from '../consts';
     </div>
   </nav>
 </header>
+
+<script>
+  const KEY = 'theme';
+  const order = ['system', 'light', 'dark'];
+  const html = document.documentElement;
+  const btn = document.getElementById('theme-toggle');
+  const labels: Record<string, string> = { system: '시스템', light: '라이트', dark: '다크' };
+
+  const get = () => {
+    try {
+      return localStorage.getItem(KEY) || 'system';
+    } catch {
+      return 'system';
+    }
+  };
+  const store = (m: string) => {
+    try {
+      m === 'system' ? localStorage.removeItem(KEY) : localStorage.setItem(KEY, m);
+    } catch {}
+  };
+  const apply = (m: string) => {
+    if (m === 'system') delete html.dataset.theme;
+    else html.dataset.theme = m;
+    btn?.setAttribute('aria-label', `테마: ${labels[m]} (클릭해 전환)`);
+  };
+
+  apply(get());
+  btn?.addEventListener('click', () => {
+    const next = order[(order.indexOf(get()) + 1) % order.length];
+    store(next);
+    apply(next);
+  });
+</script>
+
 <style>
   header {
     position: sticky;
@@ -106,6 +153,25 @@ import { SITE_TITLE } from '../consts';
   .search {
     display: flex;
     align-items: center;
+  }
+  .theme-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    padding: 0;
+    color: var(--text-muted);
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+  }
+  .theme-toggle:hover {
+    color: var(--text);
+    background: var(--bg-soft);
+    border-color: var(--border-strong);
   }
   .social-links {
     display: flex;

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -23,7 +23,7 @@ import { SITE_TITLE } from '../consts';
     <div class="search">
       <Search />
     </div>
-    <button id="theme-toggle" class="theme-toggle" type="button" title="테마 전환" aria-label="테마 전환">
+    <button id="theme-toggle" class="theme-toggle" type="button" aria-label="테마 전환" data-tip="테마 전환">
       <svg class="i-system" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <rect x="2" y="3" width="20" height="14" rx="2"></rect>
         <path d="M8 21h8M12 17v4"></path>
@@ -74,7 +74,7 @@ import { SITE_TITLE } from '../consts';
     else html.dataset.theme = m;
     const text = `테마 전환 · 현재: ${labels[m]}`;
     btn?.setAttribute('aria-label', text);
-    btn?.setAttribute('title', text);
+    btn?.setAttribute('data-tip', text);
   };
 
   apply(get());
@@ -157,6 +157,7 @@ import { SITE_TITLE } from '../consts';
     align-items: center;
   }
   .theme-toggle {
+    position: relative;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -174,6 +175,36 @@ import { SITE_TITLE } from '../consts';
     color: var(--text);
     background: var(--bg-soft);
     border-color: var(--border-strong);
+  }
+  /* 커스텀 툴팁: 네이티브 title 보다 빠르게 표시 */
+  .theme-toggle::after {
+    content: attr(data-tip);
+    position: absolute;
+    top: calc(100% + 8px);
+    right: 0;
+    z-index: 60;
+    white-space: nowrap;
+    padding: 0.3rem 0.5rem;
+    font-size: 0.75rem;
+    line-height: 1.3;
+    color: var(--bg);
+    background: var(--text);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-md);
+    opacity: 0;
+    transform: translateY(-3px);
+    pointer-events: none;
+    transition: opacity 0.12s ease, transform 0.12s ease;
+  }
+  .theme-toggle:hover::after,
+  .theme-toggle:focus-visible::after {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .theme-toggle::after {
+      transition: none;
+    }
   }
   .social-links {
     display: flex;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -29,8 +29,10 @@
   --content-width-wide: 960px;
 }
 
+/* 다크 팔레트: 명시적 data-theme="dark" 또는, 선택이 없을 때(OS 다크) 적용.
+   data-theme="light" 이면 강제 라이트. */
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme='light']) {
     --bg: #0e1117;
     --bg-soft: #161b22;
     --bg-elevated: #1c222b;
@@ -46,6 +48,22 @@
     --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4), 0 2px 4px rgba(0, 0, 0, 0.3);
     color-scheme: dark;
   }
+}
+:root[data-theme='dark'] {
+  --bg: #0e1117;
+  --bg-soft: #161b22;
+  --bg-elevated: #1c222b;
+  --text: #e6e8eb;
+  --text-muted: #9aa3b2;
+  --text-faint: #6b7280;
+  --border: #2a313c;
+  --border-strong: #3a424f;
+  --accent: #60a5fa;
+  --accent-hover: #93c5fd;
+  --code-bg: #1c222b;
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4), 0 1px 3px rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4), 0 2px 4px rgba(0, 0, 0, 0.3);
+  color-scheme: dark;
 }
 
 @font-face {
@@ -258,4 +276,16 @@ hr {
   clip: rect(1px, 1px, 1px, 1px);
   clip-path: inset(50%);
   white-space: nowrap;
+}
+
+/* 테마 토글 버튼: 현재 모드 아이콘만 표시 (data-theme 미설정 = 시스템) */
+.theme-toggle .i-system,
+.theme-toggle .i-light,
+.theme-toggle .i-dark {
+  display: none;
+}
+:root:not([data-theme]) .theme-toggle .i-system,
+:root[data-theme='light'] .theme-toggle .i-light,
+:root[data-theme='dark'] .theme-toggle .i-dark {
+  display: block;
 }


### PR DESCRIPTION
- 헤더 버튼으로 system→light→dark 순환, localStorage 저장
- BaseHead 인라인 스크립트로 페인트 전 적용해 FOUC 방지
- global.css: data-theme 기반 팔레트 전환(미설정 시 OS 설정 따름)