### PR TITLE
fix: 가독성 개선 (메타 텍스트 대비 + 본문 폰트)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -14,7 +14,7 @@
   --bg-elevated: #ffffff;
   --text: #1a1d24;
   --text-muted: #5b6577;
-  --text-faint: #8a93a3;
+  --text-faint: #6b7585;
   --border: #e5e8ee;
   --border-strong: #d3d8e0;
   --accent: #2563eb;
@@ -38,7 +38,7 @@
     --bg-elevated: #1c222b;
     --text: #e6e8eb;
     --text-muted: #9aa3b2;
-    --text-faint: #6b7280;
+    --text-faint: #7a8494;
     --border: #2a313c;
     --border-strong: #3a424f;
     --accent: #60a5fa;
@@ -55,7 +55,7 @@
   --bg-elevated: #1c222b;
   --text: #e6e8eb;
   --text-muted: #9aa3b2;
-  --text-faint: #6b7280;
+  --text-faint: #7a8494;
   --border: #2a313c;
   --border-strong: #3a424f;
   --accent: #60a5fa;
@@ -156,6 +156,11 @@ p {
   margin: 0 0 1em;
 }
 
+/* 본문은 읽기 편하도록 데스크톱에서 살짝 큰 폰트 (모바일은 아래 미디어쿼리에서 16px) */
+.prose,
+.weekly-prose {
+  font-size: 1.0625rem;
+}
 .prose p,
 .weekly-prose p {
   margin-bottom: 1.5em;
@@ -268,7 +273,11 @@ hr {
     font-size: 0.85rem;
   }
 
-  /* 모바일 본문: 들여쓰기·간격을 촘촘하게 해 가독성↑ */
+  /* 모바일 본문: 16px 유지(iOS 줌 방지) + 들여쓰기·간격을 촘촘하게 해 가독성↑ */
+  .prose,
+  .weekly-prose {
+    font-size: 1rem;
+  }
   .prose p,
   .weekly-prose p {
     margin-bottom: 1.1em;


### PR DESCRIPTION
- text-faint 색을 WCAG AA(4.5:1) 충족하도록 조정 (라이트 3.10→4.66:1, 다크 3.91→5.00:1) — 날짜·메타 가독성↑
- 본문(.prose/.weekly-prose) 데스크톱 폰트 16→17px (모바일 16px 유지)