### PR TITLE
fix: 최근 위클리 글 날짜 표기 정규화 (...Z → +09:00)

### DIFF
--- a/src/content/weekly/dev-weekly-20260523.md
+++ b/src/content/weekly/dev-weekly-20260523.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2026-05-23
-date: "2026-05-23T21:31:00.000Z"
+date: "2026-05-23T21:31:00+09:00"
 description: "dev-weekly 2026-05-23"
 tags: ["css", "javascript", "node", "i18n", "accessibility", "web-components", "npm", "fetch"]
 ---

--- a/src/content/weekly/dev-weekly-20260530.md
+++ b/src/content/weekly/dev-weekly-20260530.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2026-05-30
-date: "2026-05-30T22:47:00.000Z"
+date: "2026-05-30T22:47:00+09:00"
 description: "dev-weekly 2026-05-30"
 tags: ["css", "javascript", "animation", "font", "json", "wasm", "deno"]
 ---

--- a/src/content/weekly/dev-weekly-20260606.md
+++ b/src/content/weekly/dev-weekly-20260606.md
@@ -1,6 +1,6 @@
 ---
 title: dev-weekly 2026-06-06
-date: "2026-06-06T16:30:00.000Z"
+date: "2026-06-06T16:30:00+09:00"
 description: "dev-weekly 2026-06-06"
 tags: ["typescript", "javascript", "ai", "wasm", "node", "vite", "cloudflare", "astro"]
 ---


### PR DESCRIPTION
- dev-weekly 20260606/20260530/20260523 의 date 가 UTC(...Z)로 저장돼 KST 기준 하루 뒤(미래)로 표시되던 문제 수정
- scripts/normalize-dates.mjs 로 벽시계 시각을 KST 의도로 변환