### PR TITLE
fix: 정식 도메인을 www 로 통일 (GSC 색인 불일치 해결)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,7 +7,7 @@ import pagefind from 'astro-pagefind';
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://stupidk.com',
+  site: 'https://www.stupidk.com',
   integrations: [mdx(), sitemap(), pagefind()],
   redirects: {},
   markdown: {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://stupidk.com/sitemap-index.xml
+Sitemap: https://www.stupidk.com/sitemap-index.xml

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "redirects": [
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "stupidk.com" }],
+      "destination": "https://www.stupidk.com/:path*",
+      "permanent": true
+    }
+  ]
+}


### PR DESCRIPTION
- GSC 속성은 www 인데 canonical 이 non-www 라, www 페이지가 "대체 canonical" 로 분류되어 색인에서 빠지던 문제 해결
- astro site, robots.txt sitemap 을 www 로 변경 (canonical/sitemap/RSS 반영)
- vercel.json: apex(non-www) → www 301 리다이렉트 추가