### PR TITLE
style: 날짜 표기 월·일 2자리 0패딩 + tabular-nums 정렬

### DIFF
--- a/src/components/FormattedDate.astro
+++ b/src/components/FormattedDate.astro
@@ -15,12 +15,20 @@ const iso = parsedDate.toISOString();
 // toLocaleDateString 을 그냥 쓰면 빌드 서버 TZ(로컬 KST vs 배포 UTC)에 따라
 // 자정 근처 날짜가 하루씩 달라지므로, timeZone 을 명시해 결정론적으로 만든다.
 // 렌더 후에는 아래 스크립트가 브라우저 TZ 기준으로 다시 포맷한다.
-const fallback = new Intl.DateTimeFormat('ko-KR', {
-  timeZone: 'Asia/Seoul',
-  year: 'numeric',
-  month: 'short',
-  day: 'numeric',
-}).format(parsedDate);
+//
+// "YYYY년 MM월 DD일" 로 월·일을 2자리 0-패딩한다(tabular-nums 와 함께 폭을 균일하게).
+// ko-KR + month/day:'2-digit' 은 "2026. 06. 06." 형태라 년/월/일 마커가 사라지므로 직접 조립한다.
+const kst = Object.fromEntries(
+  new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  })
+    .formatToParts(parsedDate)
+    .map((p) => [p.type, p.value])
+);
+const fallback = `${kst.year}년 ${kst.month}월 ${kst.day}일`;
 ---
 
 <time
@@ -39,10 +47,8 @@ const fallback = new Intl.DateTimeFormat('ko-KR', {
     if (!iso) continue;
     const d = new Date(iso);
     if (Number.isNaN(d.getTime())) continue;
-    el.textContent = d.toLocaleDateString('ko-KR', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-    });
+    const mm = String(d.getMonth() + 1).padStart(2, '0');
+    const dd = String(d.getDate()).padStart(2, '0');
+    el.textContent = `${d.getFullYear()}년 ${mm}월 ${dd}일`;
   }
 </script>

--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -105,11 +105,10 @@
   function fmtDate(raw: string) {
     const t = Date.parse(raw);
     if (Number.isNaN(t)) return '';
-    return new Date(t).toLocaleDateString('ko-KR', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-    });
+    const d = new Date(t);
+    const mm = String(d.getMonth() + 1).padStart(2, '0');
+    const dd = String(d.getDate()).padStart(2, '0');
+    return `${d.getFullYear()}년 ${mm}월 ${dd}일`;
   }
 
   function setMessage(html: string) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -27,6 +27,8 @@
   --radius-lg: 14px;
   --content-width: 720px;
   --content-width-wide: 960px;
+
+  font-variant-numeric: tabular-nums;
 }
 
 /* 다크 팔레트: 명시적 data-theme="dark" 또는, 선택이 없을 때(OS 다크) 적용.


### PR DESCRIPTION
- FormattedDate(빌드 폴백/클라이언트)와 Search 결과 날짜를 "YYYY년 MM월 DD일" 형태로 월·일을 0-패딩해 통일
- ko-KR 에 month/day:'2-digit' 을 주면 "2026. 06. 06." 로 년/월/일 마커가 사라지므로, 마커를 유지하며 직접 조립
- global.css 에 font-variant-numeric: tabular-nums 적용해 숫자 폭 균일화