### PR TITLE
fix: 정식 도메인을 non-www 로 전환 (Google 색인 정렬)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,7 +7,7 @@ import pagefind from 'astro-pagefind';
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://www.stupidk.com',
+  site: 'https://stupidk.com',
   integrations: [mdx(), sitemap(), pagefind()],
   redirects: {},
   markdown: {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://www.stupidk.com/sitemap-index.xml
+Sitemap: https://stupidk.com/sitemap-index.xml

--- a/vercel.json
+++ b/vercel.json
@@ -3,8 +3,8 @@
   "redirects": [
     {
       "source": "/:path*",
-      "has": [{ "type": "host", "value": "stupidk.com" }],
-      "destination": "https://www.stupidk.com/:path*",
+      "has": [{ "type": "host", "value": "www.stupidk.com" }],
+      "destination": "https://stupidk.com/:path*",
       "permanent": true
     }
   ]


### PR DESCRIPTION
GSC 확인 결과 Google 이 이미 non-www 를 표준으로 선택해 색인 ~300페이지를 non-www 에 보유 중인 반면 www 는 12페이지뿐이라, www 강제(다른 표준 선택 에러)를 멈추고 Google 의 기존 색인에 맞춰 non-www 를 정본으로 통일한다.

- astro site → https://stupidk.com (canonical/sitemap/RSS 비-www)
- robots.txt sitemap → non-www
- vercel.json: www → non-www 301 로 리다이렉트 방향 반대로

배포 전 Vercel 대시보드에서 non-www(stupidk.com) Primary, www 는 redirect 로 바꾸고, GSC non-www 속성에 sitemap 제출 필요.